### PR TITLE
Adding ability to supply a specific 'source' on the command line for content and package stores as well as telemetry to support proxy API scenario requirements.

### DIFF
--- a/.pipelines/azure-pipelines.yml
+++ b/.pipelines/azure-pipelines.yml
@@ -55,7 +55,7 @@ steps:
   displayName: 'Build Solutions'
 
   # Build NuGet packages for the services/agents in the repo.
-- script: $(Build.SourcesDirectory)\build-packages.cmd 0.0.6
+- script: $(Build.SourcesDirectory)\build-packages.cmd 0.0.7
   displayName: 'Build NuGet Packages'
 
 - task: EsrpCodeSigning@1

--- a/src/VirtualClient/CodeQuality.targets
+++ b/src/VirtualClient/CodeQuality.targets
@@ -5,16 +5,13 @@
          Static/Code Analysis Packages
       *********************************************************************** -->
     <ItemGroup>
-        <PackageReference Include="AsyncFixer" Version="1.5.1">
-            <PrivateAssets>All</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+        <PackageReference Include="AsyncFixer" Version="1.6.0">
             <PrivateAssets>All</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.0">
             <PrivateAssets>All</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0-preview1.22518.1">
             <PrivateAssets>All</PrivateAssets>
         </PackageReference>
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/src/VirtualClient/VirtualClient.Actions/Memcached/MemcachedServerExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Memcached/MemcachedServerExecutor.cs
@@ -22,6 +22,7 @@ namespace VirtualClient.Actions
     public class MemcachedServerExecutor : MemcachedExecutor
     {
         private IProcessProxy process;
+        private bool disposed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MemcachedServerExecutor"/> class.
@@ -117,6 +118,22 @@ namespace VirtualClient.Actions
             await base.InitializeAsync(telemetryContext, cancellationToken).ConfigureAwait(false);
             this.Copies = Environment.ProcessorCount.ToString();
             this.InitializeApiClients();
+        }
+
+        /// <summary>
+        /// Disposes of resources used by the instance.
+        /// </summary>
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing)
+            {
+                if (!this.disposed)
+                {
+                    this.process?.Dispose();
+                    this.disposed = true;
+                }
+            }
         }
 
         private async Task ExecuteServerWorkload(CancellationToken cancellationToken)

--- a/src/VirtualClient/VirtualClient.Contracts/Constants.cs
+++ b/src/VirtualClient/VirtualClient.Contracts/Constants.cs
@@ -49,4 +49,25 @@ namespace VirtualClient.Contracts
         /// </summary>
         public const string DefaultDisk = "disk";
     }
+
+    /// <summary>
+    /// Global or well-known parameters available for use on the Virtual Client command line.
+    /// </summary>
+    public class GlobalParameter
+    {
+        /// <summary>
+        /// ContentStoreSource
+        /// </summary>
+        public const string ContestStoreSource = "ContentStoreSource";
+
+        /// <summary>
+        /// PackageStoreSource
+        /// </summary>
+        public const string PackageStoreSource = "PackageStoreSource";
+
+        /// <summary>
+        /// TelemetrySource
+        /// </summary>
+        public const string TelemetrySource = "TelemetrySource";
+    }
 }

--- a/src/VirtualClient/VirtualClient.Contracts/Proxy/ProxyBlobDescriptor.cs
+++ b/src/VirtualClient/VirtualClient.Contracts/Proxy/ProxyBlobDescriptor.cs
@@ -12,6 +12,11 @@ namespace VirtualClient.Contracts.Proxy
     public class ProxyBlobDescriptor
     {
         /// <summary>
+        /// The default source to use when interfacing with a proxy API service.
+        /// </summary>
+        public const string DefaultSource = "VirtualClient";
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ProxyBlobDescriptor"/> class.
         /// </summary>
         /// <param name="source">The source of the blob upload/download request (e.g. VirtualClient).</param>

--- a/src/VirtualClient/VirtualClient.Core.UnitTests/Proxy/ProxyLoggerTests.cs
+++ b/src/VirtualClient/VirtualClient.Core.UnitTests/Proxy/ProxyLoggerTests.cs
@@ -56,6 +56,26 @@ namespace VirtualClient.Proxy
         }
 
         [Test]
+        public void ProxyLoggerUsesTheExpectedSourceWhenAnExplicitSourceIsProvided()
+        {
+            string expectedSource = "AnySource";
+            this.mockProxyLogger = new TestProxyLogger(this.mockProxyApiClient.Object, expectedSource);
+            this.mockProxyLogger.Log(LogLevel.Information, new EventId(123, "AnyName"), EventContext.None, null, null);
+            ProxyTelemetryMessage messageLogged = this.mockProxyLogger.Buffer.Dequeue();
+
+            Assert.AreEqual(expectedSource, messageLogged.Source);
+        }
+
+        [Test]
+        public void ProxyLoggerUsesTheExpectedSourceWhenAnExplicitSourceIsNotProvided()
+        {
+            this.mockProxyLogger.Log(LogLevel.Information, new EventId(123, "AnyName"), EventContext.None, null, null);
+            ProxyTelemetryMessage messageLogged = this.mockProxyLogger.Buffer.Dequeue();
+
+            Assert.AreEqual(ProxyBlobDescriptor.DefaultSource, messageLogged.Source);
+        }
+
+        [Test]
         public void ProxyLoggerAddsMessagesToTheBufferInExpectedOrder()
         {
             List<ProxyTelemetryMessage> expectedEvents = new List<ProxyTelemetryMessage>
@@ -336,8 +356,8 @@ namespace VirtualClient.Proxy
 
         private class TestProxyLogger : ProxyLogger
         {
-            public TestProxyLogger(IProxyApiClient apiClient)
-                : base(apiClient)
+            public TestProxyLogger(IProxyApiClient apiClient, string source = null)
+                : base(apiClient, source)
             {
             }
 

--- a/src/VirtualClient/VirtualClient.Core/DependencyFactory.cs
+++ b/src/VirtualClient/VirtualClient.Core/DependencyFactory.cs
@@ -292,12 +292,13 @@ namespace VirtualClient
         /// endpoint.
         /// </summary>
         /// <param name="storeDescription">Describes the type of blob store (e.g. Content, Packages).</param>
-        public static IBlobManager CreateProxyBlobManager(DependencyProxyStore storeDescription)
+        /// <param name="source">An explicit source to use for blob uploads/downloads through the proxy API.</param>
+        public static IBlobManager CreateProxyBlobManager(DependencyProxyStore storeDescription, string source = null)
         {
             storeDescription.ThrowIfNull(nameof(storeDescription));
 
             VirtualClientProxyApiClient proxyApiClient = DependencyFactory.CreateVirtualClientProxyApiClient(storeDescription.ProxyApiUri, TimeSpan.FromHours(6));
-            return new ProxyBlobManager(storeDescription, proxyApiClient);
+            return new ProxyBlobManager(storeDescription, proxyApiClient, source);
         }
 
         /// <summary>

--- a/src/VirtualClient/VirtualClient.Core/Proxy/ProxyLogger.cs
+++ b/src/VirtualClient/VirtualClient.Core/Proxy/ProxyLogger.cs
@@ -50,7 +50,8 @@ namespace VirtualClient.Proxy
         /// Initializes a new instance of the <see cref="ProxyLogger"/> class.
         /// </summary>
         /// <param name="apiClient">The API client for interacting with the proxy endpoint.</param>
-        public ProxyLogger(IProxyApiClient apiClient)
+        /// <param name="source">Defines an explicit source to use for telemetry uploads.</param>
+        public ProxyLogger(IProxyApiClient apiClient, string source = null)
         {
             apiClient.ThrowIfNull(nameof(apiClient));
 
@@ -61,6 +62,10 @@ namespace VirtualClient.Proxy
             this.TransmissionFailureWaitTime = TimeSpan.FromSeconds(5);
             this.cancellationTokenSource = new CancellationTokenSource();
             this.autoFlushWaitHandle = new AutoResetEvent(false);
+
+            this.Source = !string.IsNullOrWhiteSpace(source)
+                ? source
+                : ProxyBlobDescriptor.DefaultSource;
         }
 
         /// <summary>
@@ -98,6 +103,11 @@ namespace VirtualClient.Proxy
         protected Queue<ProxyTelemetryMessage> Buffer { get; private set; }
 
         /// <summary>
+        /// Defines an explicit source to use for telemetry uploads.
+        /// </summary>
+        protected string Source { get; }
+
+        /// <summary>
         /// Not implemented.
         /// </summary>
         public IDisposable BeginScope<TState>(TState state)
@@ -133,7 +143,7 @@ namespace VirtualClient.Proxy
 
                 ProxyTelemetryMessage message = new ProxyTelemetryMessage
                 {
-                    Source = "VirtualClient",
+                    Source = this.Source,
                     EventType = eventType,
                     Message = eventId.Name,
                     ItemType = "trace",

--- a/src/VirtualClient/VirtualClient.Core/Proxy/ProxyLoggerProvider.cs
+++ b/src/VirtualClient/VirtualClient.Core/Proxy/ProxyLoggerProvider.cs
@@ -10,15 +10,18 @@ namespace VirtualClient.Proxy
     internal class ProxyLoggerProvider : ILoggerProvider
     {
         private IProxyApiClient proxyApiClient;
+        private string source;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProxyLoggerProvider"/> class.
         /// </summary>
         /// <param name="apiClient">A client to the proxy API service including its port (e.g. http://any.proxy.uri:5000).</param>
-        public ProxyLoggerProvider(IProxyApiClient apiClient)
+        /// <param name="source">The source to use when uploading telemetry through the proxy API.</param>
+        public ProxyLoggerProvider(IProxyApiClient apiClient, string source = null)
         {
             apiClient.ThrowIfNull(nameof(apiClient));
             this.proxyApiClient = apiClient;
+            this.source = source;
         }
 
         /// <summary>
@@ -26,7 +29,7 @@ namespace VirtualClient.Proxy
         /// </summary>
         public ILogger CreateLogger(string categoryName)
         {
-            ProxyLogger logger = new ProxyLogger(this.proxyApiClient);
+            ProxyLogger logger = new ProxyLogger(this.proxyApiClient, this.source);
             logger.BeginMessageTransmission();
             return logger;
         }

--- a/src/VirtualClient/VirtualClient.Main/RunBootstrapCommand.cs
+++ b/src/VirtualClient/VirtualClient.Main/RunBootstrapCommand.cs
@@ -23,11 +23,6 @@ namespace VirtualClient
         public string ExperimentId { get; set; }
 
         /// <summary>
-        /// Metadata properties (key/value pairs) supplied to the application.
-        /// </summary>
-        public IDictionary<string, IConvertible> Metadata { get; set; }
-
-        /// <summary>
         /// The name of the package to bootstrap/install.
         /// </summary>
         public string Name { get; set; }

--- a/src/VirtualClient/VirtualClient.Main/RunProfileCommand.cs
+++ b/src/VirtualClient/VirtualClient.Main/RunProfileCommand.cs
@@ -51,16 +51,6 @@ namespace VirtualClient
         public string LayoutPath { get; set; }
 
         /// <summary>
-        /// Metadata properties (key/value pairs) supplied to the application.
-        /// </summary>
-        public IDictionary<string, IConvertible> Metadata { get; set; }
-
-        /// <summary>
-        /// Additional or override parameters (key/value pairs) supplied to the application.
-        /// </summary>
-        public IDictionary<string, IConvertible> Parameters { get; set; }
-
-        /// <summary>
         /// The workload/monitoring profiles to execute (e.g. PERF-CPU-OPENSSL.json).
         /// </summary>
         public List<string> Profiles { get; set; }

--- a/src/VirtualClient/VirtualClient.Main/VirtualClient.Main.csproj
+++ b/src/VirtualClient/VirtualClient.Main/VirtualClient.Main.csproj
@@ -41,48 +41,48 @@
     </ItemGroup>
 
     <ItemGroup>
-		<None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\system_list.py" Link="scripts\mlperf\GPUConfigFiles\system_list.py">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\bert\Offline\__init__.py" Link="scripts\mlperf\GPUConfigFiles\bert\Offline\__init__.py">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\bert\Server\__init__.py" Link="scripts\mlperf\GPUConfigFiles\bert\Server\__init__.py">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\bert\SingleStream\__init__.py" Link="scripts\mlperf\GPUConfigFiles\bert\SingleStream\__init__.py">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\rnnt\Offline\__init__.py" Link="scripts\mlperf\GPUConfigFiles\rnnt\Offline\__init__.py">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\rnnt\Server\__init__.py" Link="scripts\mlperf\GPUConfigFiles\rnnt\Server\__init__.py">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\rnnt\SingleStream\__init__.py" Link="scripts\mlperf\GPUConfigFiles\rnnt\SingleStream\__init__.py">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\ssd-mobilenet\Offline\__init__.py" Link="scripts\mlperf\GPUConfigFiles\ssd-mobilenet\Offline\__init__.py">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\ssd-mobilenet\MultiStream\__init__.py" Link="scripts\mlperf\GPUConfigFiles\ssd-mobilenet\MultiStream\__init__.py">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\ssd-mobilenet\SingleStream\__init__.py" Link="scripts\mlperf\GPUConfigFiles\ssd-mobilenet\SingleStream\__init__.py">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\ssd-resnet34\Offline\__init__.py" Link="scripts\mlperf\GPUConfigFiles\ssd-resnet34\Offline\__init__.py">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\ssd-resnet34\MultiStream\__init__.py" Link="scripts\mlperf\GPUConfigFiles\ssd-resnet34\MultiStream\__init__.py">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\ssd-resnet34\SingleStream\__init__.py" Link="scripts\mlperf\GPUConfigFiles\ssd-resnet34\SingleStream\__init__.py">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\ssd-resnet34\Server\__init__.py" Link="scripts\mlperf\GPUConfigFiles\ssd-resnet34\Server\__init__.py">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
+        <None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\system_list.py" Link="scripts\mlperf\GPUConfigFiles\system_list.py">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\bert\Offline\__init__.py" Link="scripts\mlperf\GPUConfigFiles\bert\Offline\__init__.py">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\bert\Server\__init__.py" Link="scripts\mlperf\GPUConfigFiles\bert\Server\__init__.py">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\bert\SingleStream\__init__.py" Link="scripts\mlperf\GPUConfigFiles\bert\SingleStream\__init__.py">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\rnnt\Offline\__init__.py" Link="scripts\mlperf\GPUConfigFiles\rnnt\Offline\__init__.py">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\rnnt\Server\__init__.py" Link="scripts\mlperf\GPUConfigFiles\rnnt\Server\__init__.py">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\rnnt\SingleStream\__init__.py" Link="scripts\mlperf\GPUConfigFiles\rnnt\SingleStream\__init__.py">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\ssd-mobilenet\Offline\__init__.py" Link="scripts\mlperf\GPUConfigFiles\ssd-mobilenet\Offline\__init__.py">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\ssd-mobilenet\MultiStream\__init__.py" Link="scripts\mlperf\GPUConfigFiles\ssd-mobilenet\MultiStream\__init__.py">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\ssd-mobilenet\SingleStream\__init__.py" Link="scripts\mlperf\GPUConfigFiles\ssd-mobilenet\SingleStream\__init__.py">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\ssd-resnet34\Offline\__init__.py" Link="scripts\mlperf\GPUConfigFiles\ssd-resnet34\Offline\__init__.py">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\ssd-resnet34\MultiStream\__init__.py" Link="scripts\mlperf\GPUConfigFiles\ssd-resnet34\MultiStream\__init__.py">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\ssd-resnet34\SingleStream\__init__.py" Link="scripts\mlperf\GPUConfigFiles\ssd-resnet34\SingleStream\__init__.py">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="..\VirtualClient.Actions\MLPerf\GPUConfigFiles\ssd-resnet34\Server\__init__.py" Link="scripts\mlperf\GPUConfigFiles\ssd-resnet34\Server\__init__.py">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
         <None Include="..\VirtualClient.Actions\SuperBenchmark\default.yaml" Link="scripts\superbenchmark\default.yaml">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
@@ -124,7 +124,7 @@
         Below we have targets that copy the relevant profiles to the target platform/arch folders based upon the
         supported operating system.
         -->
-      <Content Update="profiles\*.json" CopyToOutputDirectory="Always" CopyToPublishDirectory="Never" />
+        <Content Update="profiles\*.json" CopyToOutputDirectory="Always" CopyToPublishDirectory="Never" />
     </ItemGroup>
 
     <ItemGroup>
@@ -146,7 +146,7 @@
         <WindowsProfiles Include="profiles\PERF-IO-FIO-MULTITHROUGHPUT.json" />
         <WindowsProfiles Include="profiles\PERF-NETWORK-PING.json" />
         <WindowsProfiles Include="profiles\PERF-NETWORK.json" />
-	    <WindowsProfiles Include="profiles\PERF-NETWORK-2.json" />
+        <WindowsProfiles Include="profiles\PERF-NETWORK-2.json" />
         <WindowsProfiles Include="profiles\PERF-OPENFOAM.json" />
         <WindowsProfiles Include="profiles\PERF-SPECJVM.json" />
     </ItemGroup>
@@ -159,7 +159,7 @@
         -->
         <LinuxProfiles Include="profiles\GET-STARTED-OPENSSL.json" />
         <LinuxProfiles Include="profiles\GET-STARTED-REDIS.json" />
-		<LinuxProfiles Include="profiles\BOOTSTRAP-DEPENDENCIES.json" />
+        <LinuxProfiles Include="profiles\BOOTSTRAP-DEPENDENCIES.json" />
         <LinuxProfiles Include="profiles\PERF-ASPNETBENCH.json" />
         <LinuxProfiles Include="profiles\PERF-COMPRESSION.json" />
         <LinuxProfiles Include="profiles\PERF-CPU-COREMARK.json" />
@@ -167,7 +167,7 @@
         <LinuxProfiles Include="profiles\PERF-CPU-OPENSSL.json" />
         <LinuxProfiles Include="profiles\PERF-CPU-PRIME95.json" />
         <LinuxProfiles Include="profiles\PERF-GPU-SUPERBENCH.json" />
-		<LinuxProfiles Include="profiles\PERF-GPU-MLPERF.json" />
+        <LinuxProfiles Include="profiles\PERF-GPU-MLPERF.json" />
         <LinuxProfiles Include="profiles\PERF-GRAPH500.json" />
         <LinuxProfiles Include="profiles\PERF-HPC-NASPARALLELBENCH.json" />
         <LinuxProfiles Include="profiles\PERF-IO-FIO.json" />
@@ -176,13 +176,13 @@
         <LinuxProfiles Include="profiles\PERF-CPU-LAPACK.json" />
         <LinuxProfiles Include="profiles\PERF-STRESSNG.json" />
         <LinuxProfiles Include="profiles\PERF-MEM-LMBENCH.json" />
-		<LinuxProfiles Include="profiles\PERF-MYSQL-SYSBENCH-OLTP.json" />
+        <LinuxProfiles Include="profiles\PERF-MYSQL-SYSBENCH-OLTP.json" />
         <LinuxProfiles Include="profiles\PERF-REDIS.json" />
         <LinuxProfiles Include="profiles\PERF-MEMCACHED.json" />
         <LinuxProfiles Include="profiles\PERF-NETWORK-PING.json" />
         <LinuxProfiles Include="profiles\PERF-NETWORK.json" />
         <LinuxProfiles Include="profiles\PERF-NETWORK-DEATHSTARBENCH.json" />
-		<LinuxProfiles Include="profiles\PERF-NETWORK-2.json" />
+        <LinuxProfiles Include="profiles\PERF-NETWORK-2.json" />
         <LinuxProfiles Include="profiles\PERF-SPECJVM.json" />
         <LinuxProfiles Include="profiles\PERF-OPENFOAM.json" />
     </ItemGroup>
@@ -193,7 +193,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Folder Include="Properties\" />
+        <Folder Include="Properties\" />
     </ItemGroup>
 
     <Target Name="PublishProfiles" AfterTargets="Publish">
@@ -211,5 +211,5 @@
 
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Module.props))\Module.props" />
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Module.props))\NuGetPackaging.targets" />
-   
+
 </Project>


### PR DESCRIPTION
Current requirements for offsite manufacturing facility scenarios requires that the data (logs) and telemetry output by VC be uploaded to different data stores (by vendor). To enable support for this, the user/automation must be able to supply instructions to VC on the command line. We will be using the --parameters option to provide this information to the proxy interfacing classes (blob manager and logger).