### PR TITLE
Proper versioning for extensions

### DIFF
--- a/.pipelines/azure-pipelines.yml
+++ b/.pipelines/azure-pipelines.yml
@@ -17,6 +17,7 @@ pool:
   vmImage: windows-latest
 
 variables:
+  VcVersion : 0.0.8
   ROOT: $(Build.SourcesDirectory)
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   ENABLE_PRS_DELAYSIGN: 1
@@ -51,11 +52,11 @@ steps:
   displayName: 'Clean Output Directories'
   
   # Build the repo.
-- script: $(Build.SourcesDirectory)\build.cmd
+- script: $(Build.SourcesDirectory)\build.cmd $(VcVersion)
   displayName: 'Build Solutions'
 
   # Build NuGet packages for the services/agents in the repo.
-- script: $(Build.SourcesDirectory)\build-packages.cmd 0.0.7
+- script: $(Build.SourcesDirectory)\build-packages.cmd $(VcVersion)
   displayName: 'Build NuGet Packages'
 
 - task: EsrpCodeSigning@1

--- a/build.cmd
+++ b/build.cmd
@@ -2,7 +2,9 @@
 
 Set ExitCode=0
 
-if "%CDP_FILE_VERSION_NUMERIC%" NEQ "" (
+if /i "%CDP_FILE_VERSION_NUMERIC%" == "" (
+    set VCBuildVersion=%~1
+) else (
     set VCBuildVersion=%CDP_FILE_VERSION_NUMERIC%
 )
 


### PR DESCRIPTION
Change telemetry appversion to align with extension dll if available. Also change Azure pipeline to build with proper desired version.