### PR TITLE
Fix bug in DataTableExtensions.GetMetrics logic for handling DBNull.Value values in rows.

### DIFF
--- a/.pipelines/azure-pipelines.yml
+++ b/.pipelines/azure-pipelines.yml
@@ -17,7 +17,7 @@ pool:
   vmImage: windows-latest
 
 variables:
-  VcVersion : 0.0.9
+  VcVersion : 0.0.10
   ROOT: $(Build.SourcesDirectory)
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   ENABLE_PRS_DELAYSIGN: 1

--- a/src/VirtualClient/VirtualClient.Actions/CoreMark/CoreMarkMetricsParser.cs
+++ b/src/VirtualClient/VirtualClient.Actions/CoreMark/CoreMarkMetricsParser.cs
@@ -43,7 +43,7 @@ namespace VirtualClient.Actions
 
             List<Metric> metrics = new List<Metric>();
 
-            metrics.AddRange(this.CoreMarkResult.GetMetric(nameIndex: 0, valueIndex: 1, unit: "NA", namePrefix: string.Empty, ignoreFormatError: true));
+            metrics.AddRange(this.CoreMarkResult.GetMetrics(nameIndex: 0, valueIndex: 1, unit: "NA", namePrefix: string.Empty, ignoreFormatError: true));
 
             // CoreMark result doesn't define the unit so needs manually assign units.
             metrics.Where(m => m.Name == "CoreMark Size").FirstOrDefault().Unit = "bytes";

--- a/src/VirtualClient/VirtualClient.Actions/CoreMark/CoreMarkProMetricsParser.cs
+++ b/src/VirtualClient/VirtualClient.Actions/CoreMark/CoreMarkProMetricsParser.cs
@@ -65,12 +65,12 @@ namespace VirtualClient.Actions
 
             List<Metric> metrics = new List<Metric>();
             
-            metrics.AddRange(this.WorkloadResult.GetMetric(nameIndex: 0, valueIndex: 1, unit: "iterations/sec", namePrefix: "MultiCore-", metricRelativity: MetricRelativity.HigherIsBetter));
-            metrics.AddRange(this.WorkloadResult.GetMetric(nameIndex: 0, valueIndex: 2, unit: "iterations/sec", namePrefix: "SingleCore-", metricRelativity: MetricRelativity.HigherIsBetter));
-            metrics.AddRange(this.WorkloadResult.GetMetric(nameIndex: 0, valueIndex: 3, unit: "scale", namePrefix: "Scaling-", metricRelativity: MetricRelativity.HigherIsBetter));
-            metrics.AddRange(this.MarkResult.GetMetric(nameIndex: 0, valueIndex: 1, unit: "Score", namePrefix: "MultiCore-", metricRelativity: MetricRelativity.HigherIsBetter));
-            metrics.AddRange(this.MarkResult.GetMetric(nameIndex: 0, valueIndex: 2, unit: "Score", namePrefix: "SingleCore-", metricRelativity: MetricRelativity.HigherIsBetter));
-            metrics.AddRange(this.MarkResult.GetMetric(nameIndex: 0, valueIndex: 3, unit: "scale", namePrefix: "Scaling-", metricRelativity: MetricRelativity.HigherIsBetter));
+            metrics.AddRange(this.WorkloadResult.GetMetrics(nameIndex: 0, valueIndex: 1, unit: "iterations/sec", namePrefix: "MultiCore-", metricRelativity: MetricRelativity.HigherIsBetter));
+            metrics.AddRange(this.WorkloadResult.GetMetrics(nameIndex: 0, valueIndex: 2, unit: "iterations/sec", namePrefix: "SingleCore-", metricRelativity: MetricRelativity.HigherIsBetter));
+            metrics.AddRange(this.WorkloadResult.GetMetrics(nameIndex: 0, valueIndex: 3, unit: "scale", namePrefix: "Scaling-", metricRelativity: MetricRelativity.HigherIsBetter));
+            metrics.AddRange(this.MarkResult.GetMetrics(nameIndex: 0, valueIndex: 1, unit: "Score", namePrefix: "MultiCore-", metricRelativity: MetricRelativity.HigherIsBetter));
+            metrics.AddRange(this.MarkResult.GetMetrics(nameIndex: 0, valueIndex: 2, unit: "Score", namePrefix: "SingleCore-", metricRelativity: MetricRelativity.HigherIsBetter));
+            metrics.AddRange(this.MarkResult.GetMetrics(nameIndex: 0, valueIndex: 3, unit: "scale", namePrefix: "Scaling-", metricRelativity: MetricRelativity.HigherIsBetter));
 
             return metrics;
         }

--- a/src/VirtualClient/VirtualClient.Actions/DiskSpd/DiskSpdMetricsParser.cs
+++ b/src/VirtualClient/VirtualClient.Actions/DiskSpd/DiskSpdMetricsParser.cs
@@ -78,27 +78,27 @@ namespace VirtualClient.Actions
 
             List<Metric> metrics = new List<Metric>();
 
-            metrics.AddRange(this.TotalIo.GetMetric(nameIndex: 0, valueIndex: 1, unit: "bytes", namePrefix: $"Total-{this.TotalIo.Columns[1].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
-            metrics.AddRange(this.TotalIo.GetMetric(nameIndex: 0, valueIndex: 2, unit: "I/Os", namePrefix: $"Total-{this.TotalIo.Columns[2].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
-            metrics.AddRange(this.TotalIo.GetMetric(nameIndex: 0, valueIndex: 3, unit: "MiB/s", namePrefix: $"Total-{this.TotalIo.Columns[3].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
-            metrics.AddRange(this.TotalIo.GetMetric(nameIndex: 0, valueIndex: 4, unit: "iops", namePrefix: $"Total-{this.TotalIo.Columns[4].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
-            metrics.AddRange(this.TotalIo.GetMetric(nameIndex: 0, valueIndex: 5, unit: "ms", namePrefix: $"Total-{this.TotalIo.Columns[5].ColumnName}-", metricRelativity: MetricRelativity.LowerIsBetter));
+            metrics.AddRange(this.TotalIo.GetMetrics(nameIndex: 0, valueIndex: 1, unit: "bytes", namePrefix: $"Total-{this.TotalIo.Columns[1].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
+            metrics.AddRange(this.TotalIo.GetMetrics(nameIndex: 0, valueIndex: 2, unit: "I/Os", namePrefix: $"Total-{this.TotalIo.Columns[2].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
+            metrics.AddRange(this.TotalIo.GetMetrics(nameIndex: 0, valueIndex: 3, unit: "MiB/s", namePrefix: $"Total-{this.TotalIo.Columns[3].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
+            metrics.AddRange(this.TotalIo.GetMetrics(nameIndex: 0, valueIndex: 4, unit: "iops", namePrefix: $"Total-{this.TotalIo.Columns[4].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
+            metrics.AddRange(this.TotalIo.GetMetrics(nameIndex: 0, valueIndex: 5, unit: "ms", namePrefix: $"Total-{this.TotalIo.Columns[5].ColumnName}-", metricRelativity: MetricRelativity.LowerIsBetter));
 
-            metrics.AddRange(this.ReadIo.GetMetric(nameIndex: 0, valueIndex: 1, unit: "bytes", namePrefix: $"Read-{this.ReadIo.Columns[1].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
-            metrics.AddRange(this.ReadIo.GetMetric(nameIndex: 0, valueIndex: 2, unit: "I/Os", namePrefix: $"Read-{this.ReadIo.Columns[2].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
-            metrics.AddRange(this.ReadIo.GetMetric(nameIndex: 0, valueIndex: 3, unit: "MiB/s", namePrefix: $"Read-{this.ReadIo.Columns[3].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
-            metrics.AddRange(this.ReadIo.GetMetric(nameIndex: 0, valueIndex: 4, unit: "iops", namePrefix: $"Read-{this.ReadIo.Columns[4].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
-            metrics.AddRange(this.ReadIo.GetMetric(nameIndex: 0, valueIndex: 5, unit: "ms", namePrefix: $"Read-{this.ReadIo.Columns[5].ColumnName}-", metricRelativity: MetricRelativity.LowerIsBetter));
+            metrics.AddRange(this.ReadIo.GetMetrics(nameIndex: 0, valueIndex: 1, unit: "bytes", namePrefix: $"Read-{this.ReadIo.Columns[1].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
+            metrics.AddRange(this.ReadIo.GetMetrics(nameIndex: 0, valueIndex: 2, unit: "I/Os", namePrefix: $"Read-{this.ReadIo.Columns[2].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
+            metrics.AddRange(this.ReadIo.GetMetrics(nameIndex: 0, valueIndex: 3, unit: "MiB/s", namePrefix: $"Read-{this.ReadIo.Columns[3].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
+            metrics.AddRange(this.ReadIo.GetMetrics(nameIndex: 0, valueIndex: 4, unit: "iops", namePrefix: $"Read-{this.ReadIo.Columns[4].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
+            metrics.AddRange(this.ReadIo.GetMetrics(nameIndex: 0, valueIndex: 5, unit: "ms", namePrefix: $"Read-{this.ReadIo.Columns[5].ColumnName}-", metricRelativity: MetricRelativity.LowerIsBetter));
 
-            metrics.AddRange(this.WriteIo.GetMetric(nameIndex: 0, valueIndex: 1, unit: "bytes", namePrefix: $"Write-{this.WriteIo.Columns[1].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
-            metrics.AddRange(this.WriteIo.GetMetric(nameIndex: 0, valueIndex: 2, unit: "I/Os", namePrefix: $"Write-{this.WriteIo.Columns[2].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
-            metrics.AddRange(this.WriteIo.GetMetric(nameIndex: 0, valueIndex: 3, unit: "MiB/s", namePrefix: $"Write-{this.WriteIo.Columns[3].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
-            metrics.AddRange(this.WriteIo.GetMetric(nameIndex: 0, valueIndex: 4, unit: "iops", namePrefix: $"Write-{this.WriteIo.Columns[4].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
-            metrics.AddRange(this.WriteIo.GetMetric(nameIndex: 0, valueIndex: 5, unit: "ms", namePrefix: $"Write-{this.WriteIo.Columns[5].ColumnName}-", metricRelativity: MetricRelativity.LowerIsBetter));
+            metrics.AddRange(this.WriteIo.GetMetrics(nameIndex: 0, valueIndex: 1, unit: "bytes", namePrefix: $"Write-{this.WriteIo.Columns[1].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
+            metrics.AddRange(this.WriteIo.GetMetrics(nameIndex: 0, valueIndex: 2, unit: "I/Os", namePrefix: $"Write-{this.WriteIo.Columns[2].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
+            metrics.AddRange(this.WriteIo.GetMetrics(nameIndex: 0, valueIndex: 3, unit: "MiB/s", namePrefix: $"Write-{this.WriteIo.Columns[3].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
+            metrics.AddRange(this.WriteIo.GetMetrics(nameIndex: 0, valueIndex: 4, unit: "iops", namePrefix: $"Write-{this.WriteIo.Columns[4].ColumnName}-", metricRelativity: MetricRelativity.HigherIsBetter));
+            metrics.AddRange(this.WriteIo.GetMetrics(nameIndex: 0, valueIndex: 5, unit: "ms", namePrefix: $"Write-{this.WriteIo.Columns[5].ColumnName}-", metricRelativity: MetricRelativity.LowerIsBetter));
 
-            metrics.AddRange(this.Latency.GetMetric(nameIndex: 0, valueIndex: 1, unit: "ms", namePrefix: "Read-Latency-", metricRelativity: MetricRelativity.LowerIsBetter));
-            metrics.AddRange(this.Latency.GetMetric(nameIndex: 0, valueIndex: 2, unit: "ms", namePrefix: "Write-Latency-", metricRelativity: MetricRelativity.LowerIsBetter));
-            metrics.AddRange(this.Latency.GetMetric(nameIndex: 0, valueIndex: 3, unit: "ms", namePrefix: "Total-Latency-", metricRelativity: MetricRelativity.LowerIsBetter));
+            metrics.AddRange(this.Latency.GetMetrics(nameIndex: 0, valueIndex: 1, unit: "ms", namePrefix: "Read-Latency-", metricRelativity: MetricRelativity.LowerIsBetter));
+            metrics.AddRange(this.Latency.GetMetrics(nameIndex: 0, valueIndex: 2, unit: "ms", namePrefix: "Write-Latency-", metricRelativity: MetricRelativity.LowerIsBetter));
+            metrics.AddRange(this.Latency.GetMetrics(nameIndex: 0, valueIndex: 3, unit: "ms", namePrefix: "Total-Latency-", metricRelativity: MetricRelativity.LowerIsBetter));
 
             return metrics;
         }

--- a/src/VirtualClient/VirtualClient.Actions/LAPACK/LAPACKMetricsParser.cs
+++ b/src/VirtualClient/VirtualClient.Actions/LAPACK/LAPACKMetricsParser.cs
@@ -90,14 +90,14 @@ namespace VirtualClient.Actions
             this.CalculateLAPACKResult();
 
             List<Metric> metrics = new List<Metric>();
-            metrics.AddRange(this.LINSingleResult.GetMetric(nameIndex: 0, valueIndex: 2, unitIndex: 3, metricRelativity: MetricRelativity.LowerIsBetter));
-            metrics.AddRange(this.LINDoubleResult.GetMetric(nameIndex: 0, valueIndex: 2, unitIndex: 3, metricRelativity: MetricRelativity.LowerIsBetter));
-            metrics.AddRange(this.LINComplexResult.GetMetric(nameIndex: 0, valueIndex: 2, unitIndex: 3, metricRelativity: MetricRelativity.LowerIsBetter));
-            metrics.AddRange(this.LINComplexDoubleResult.GetMetric(nameIndex: 0, valueIndex: 2, unitIndex: 3, metricRelativity: MetricRelativity.LowerIsBetter));
-            metrics.AddRange(this.EIGSingleResult.GetMetric(nameIndex: 0, valueIndex: 2, unitIndex: 3, metricRelativity: MetricRelativity.LowerIsBetter));
-            metrics.AddRange(this.EIGDoubleResult.GetMetric(nameIndex: 0, valueIndex: 2, unitIndex: 3, metricRelativity: MetricRelativity.LowerIsBetter));
-            metrics.AddRange(this.EIGComplexResult.GetMetric(nameIndex: 0, valueIndex: 2, unitIndex: 3, metricRelativity: MetricRelativity.LowerIsBetter));
-            metrics.AddRange(this.EIGComplexDoubleResult.GetMetric(nameIndex: 0, valueIndex: 2, unitIndex: 3, metricRelativity: MetricRelativity.LowerIsBetter));
+            metrics.AddRange(this.LINSingleResult.GetMetrics(nameIndex: 0, valueIndex: 2, unitIndex: 3, metricRelativity: MetricRelativity.LowerIsBetter));
+            metrics.AddRange(this.LINDoubleResult.GetMetrics(nameIndex: 0, valueIndex: 2, unitIndex: 3, metricRelativity: MetricRelativity.LowerIsBetter));
+            metrics.AddRange(this.LINComplexResult.GetMetrics(nameIndex: 0, valueIndex: 2, unitIndex: 3, metricRelativity: MetricRelativity.LowerIsBetter));
+            metrics.AddRange(this.LINComplexDoubleResult.GetMetrics(nameIndex: 0, valueIndex: 2, unitIndex: 3, metricRelativity: MetricRelativity.LowerIsBetter));
+            metrics.AddRange(this.EIGSingleResult.GetMetrics(nameIndex: 0, valueIndex: 2, unitIndex: 3, metricRelativity: MetricRelativity.LowerIsBetter));
+            metrics.AddRange(this.EIGDoubleResult.GetMetrics(nameIndex: 0, valueIndex: 2, unitIndex: 3, metricRelativity: MetricRelativity.LowerIsBetter));
+            metrics.AddRange(this.EIGComplexResult.GetMetrics(nameIndex: 0, valueIndex: 2, unitIndex: 3, metricRelativity: MetricRelativity.LowerIsBetter));
+            metrics.AddRange(this.EIGComplexDoubleResult.GetMetrics(nameIndex: 0, valueIndex: 2, unitIndex: 3, metricRelativity: MetricRelativity.LowerIsBetter));
 
             return metrics;
         }

--- a/src/VirtualClient/VirtualClient.Actions/LMbench/LMbenchMetricsParser.cs
+++ b/src/VirtualClient/VirtualClient.Actions/LMbench/LMbenchMetricsParser.cs
@@ -112,48 +112,48 @@ namespace VirtualClient.Actions
 
             for (int index = 2; index < this.ProcessorTimes.Columns.Count; index++)
             {
-                metrics.AddRange(this.ProcessorTimes.GetMetric(valueIndex: index, name: this.ProcessorTimes.Columns[index].ColumnName, unit: "microseconds", namePrefix: "ProcessorTimes-"));
+                metrics.AddRange(this.ProcessorTimes.GetMetrics(valueIndex: index, name: this.ProcessorTimes.Columns[index].ColumnName, unit: "microseconds", namePrefix: "ProcessorTimes-"));
             }
 
             for (int index = 2; index < this.BasicInt.Columns.Count; index++)
             {
-                metrics.AddRange(this.BasicInt.GetMetric(valueIndex: index, name: this.BasicInt.Columns[index].ColumnName, unit: "nanoseconds", namePrefix: "BasicInt-"));
+                metrics.AddRange(this.BasicInt.GetMetrics(valueIndex: index, name: this.BasicInt.Columns[index].ColumnName, unit: "nanoseconds", namePrefix: "BasicInt-"));
             }
 
             for (int index = 2; index < this.BasicFloat.Columns.Count; index++)
             {
-                metrics.AddRange(this.BasicFloat.GetMetric(valueIndex: index, name: this.BasicFloat.Columns[index].ColumnName, unit: "nanoseconds", namePrefix: "BasicFloat-"));
+                metrics.AddRange(this.BasicFloat.GetMetrics(valueIndex: index, name: this.BasicFloat.Columns[index].ColumnName, unit: "nanoseconds", namePrefix: "BasicFloat-"));
             }
 
             for (int index = 2; index < this.BasicDouble.Columns.Count; index++)
             {
-                metrics.AddRange(this.BasicDouble.GetMetric(valueIndex: index, name: this.BasicDouble.Columns[index].ColumnName, unit: "nanoseconds", namePrefix: "BasicDouble-"));
+                metrics.AddRange(this.BasicDouble.GetMetrics(valueIndex: index, name: this.BasicDouble.Columns[index].ColumnName, unit: "nanoseconds", namePrefix: "BasicDouble-"));
             }
 
             for (int index = 2; index < this.ContextSwitching.Columns.Count; index++)
             {
-                metrics.AddRange(this.ContextSwitching.GetMetric(valueIndex: index, name: this.ContextSwitching.Columns[index].ColumnName, unit: "microseconds", namePrefix: "ContextSwitching-", metricRelativity: MetricRelativity.LowerIsBetter));
+                metrics.AddRange(this.ContextSwitching.GetMetrics(valueIndex: index, name: this.ContextSwitching.Columns[index].ColumnName, unit: "microseconds", namePrefix: "ContextSwitching-", metricRelativity: MetricRelativity.LowerIsBetter));
             }
 
             for (int index = 2; index < this.CommunicationLatency.Columns.Count; index++)
             {
-                metrics.AddRange(this.CommunicationLatency.GetMetric(valueIndex: index, name: this.CommunicationLatency.Columns[index].ColumnName, unit: "microseconds", namePrefix: "CommunicationLatency-", metricRelativity: MetricRelativity.LowerIsBetter));
+                metrics.AddRange(this.CommunicationLatency.GetMetrics(valueIndex: index, name: this.CommunicationLatency.Columns[index].ColumnName, unit: "microseconds", namePrefix: "CommunicationLatency-", metricRelativity: MetricRelativity.LowerIsBetter));
             }
 
             for (int index = 2; index < this.FileVmLatency.Columns.Count; index++)
             {
-                metrics.AddRange(this.FileVmLatency.GetMetric(valueIndex: index, name: this.FileVmLatency.Columns[index].ColumnName, unit: "microseconds", namePrefix: "FileVmLatency-", metricRelativity: MetricRelativity.LowerIsBetter));
+                metrics.AddRange(this.FileVmLatency.GetMetrics(valueIndex: index, name: this.FileVmLatency.Columns[index].ColumnName, unit: "microseconds", namePrefix: "FileVmLatency-", metricRelativity: MetricRelativity.LowerIsBetter));
             }
 
             for (int index = 2; index < this.CommunicationBandwidth.Columns.Count; index++)
             {
-                metrics.AddRange(this.CommunicationBandwidth.GetMetric(valueIndex: index, name: this.CommunicationBandwidth.Columns[index].ColumnName, unit: "MB/s", namePrefix: "CommunicationBandwidth-", metricRelativity: MetricRelativity.HigherIsBetter));
+                metrics.AddRange(this.CommunicationBandwidth.GetMetrics(valueIndex: index, name: this.CommunicationBandwidth.Columns[index].ColumnName, unit: "MB/s", namePrefix: "CommunicationBandwidth-", metricRelativity: MetricRelativity.HigherIsBetter));
             }
 
             for (int index = 2; index < this.MemoryLatency.Columns.Count - 1; index++)
             {
                 // The last column is "Guesses" which is not a metric.
-                metrics.AddRange(this.MemoryLatency.GetMetric(valueIndex: index, name: this.MemoryLatency.Columns[index].ColumnName, unit: "nanoseconds", namePrefix: "MemoryLatency-", metricRelativity: MetricRelativity.LowerIsBetter));
+                metrics.AddRange(this.MemoryLatency.GetMetrics(valueIndex: index, name: this.MemoryLatency.Columns[index].ColumnName, unit: "nanoseconds", namePrefix: "MemoryLatency-", metricRelativity: MetricRelativity.LowerIsBetter));
             }
 
             // The unit is not totally consistent in the output. Adjusting to correct units.

--- a/src/VirtualClient/VirtualClient.Contracts.UnitTests/Parser/DataTableExtensionsTests.cs
+++ b/src/VirtualClient/VirtualClient.Contracts.UnitTests/Parser/DataTableExtensionsTests.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace VirtualClient.Contracts.Parser
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Linq;
+    using NUnit.Framework;
+
+    [TestFixture]
+    [Category("Unit")]
+    internal class DataTableExtensionsTests
+    {
+        [Test]
+        public void GetMetricExtensionParsesExpectedMetricNamesAndValuesFromDataTableRows()
+        {
+            DataTable table = new DataTable();
+            table.Columns.Add(new DataColumn("Id", typeof(Guid)));
+            table.Columns.Add(new DataColumn("MetricName", typeof(string)));
+            table.Columns.Add(new DataColumn("MetricValue", typeof(double)));
+
+            table.Rows.Add(Guid.NewGuid(), "Metric1", 1234);
+            table.Rows.Add(Guid.NewGuid(), "Metric2", 9876);
+
+            IEnumerable<Metric> metrics = table.GetMetrics(nameIndex: 1, valueIndex: 2);
+
+            Assert.AreEqual(2, metrics.Count());
+            Assert.IsTrue(metrics.ElementAt(0).Name == "Metric1");
+            Assert.IsTrue(metrics.ElementAt(0).Value == 1234);
+            Assert.IsTrue(metrics.ElementAt(1).Name == "Metric2");
+            Assert.IsTrue(metrics.ElementAt(1).Value == 9876);
+        }
+
+        [Test]
+        public void GetMetricExtensionHandlesDBNullValuesInDataTableRowValues()
+        {
+            DataTable table = new DataTable();
+            table.Columns.Add(new DataColumn("Id", typeof(Guid)));
+            table.Columns.Add(new DataColumn("MetricName", typeof(string)));
+            table.Columns.Add(new DataColumn("MetricValue", typeof(double)));
+
+            table.Rows.Add(Guid.NewGuid(), "Metric1", 1234);
+            table.Rows.Add(Guid.NewGuid(), "Metric2", DBNull.Value);
+
+            IEnumerable<Metric> metrics = table.GetMetrics(nameIndex: 1, valueIndex: 2);
+
+            Assert.AreEqual(1, metrics.Count());
+            Assert.IsTrue(metrics.First().Name == "Metric1");
+            Assert.IsTrue(metrics.First().Value == 1234);
+        }
+    }
+}


### PR DESCRIPTION
This bug was found when parsing MLC results. Some of the row values in the data table end up with DBNull.Value values. The original implementation attempts to parse this as a double and exception is thrown. This work did not make it into the repo before moving to open source.