### PR TITLE
Fix .NET process intermittent output missing

### DIFF
--- a/.pipelines/azure-pipelines.yml
+++ b/.pipelines/azure-pipelines.yml
@@ -17,7 +17,7 @@ pool:
   vmImage: windows-latest
 
 variables:
-  VcVersion : 0.3.4
+  VcVersion : 0.3.5
   ROOT: $(Build.SourcesDirectory)
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   ENABLE_PRS_DELAYSIGN: 1

--- a/src/VirtualClient/VirtualClient.Actions/Examples/ClientServer/ExampleReverseProxyExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Examples/ClientServer/ExampleReverseProxyExecutor.cs
@@ -209,7 +209,7 @@ namespace VirtualClient.Actions
                 await this.StateManager.SaveStateAsync(ExampleClientServerExecutor.ServerReadyState, serverOnline, cancellationToken)
                     .ConfigureAwait(false);
 
-                await webHostProcess.WaitAsync(cancellationToken)
+                await webHostProcess.WaitForExitAsync(cancellationToken)
                     .ConfigureAwait(false);
             }
 

--- a/src/VirtualClient/VirtualClient.Actions/Examples/ClientServer/ExampleServerExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Examples/ClientServer/ExampleServerExecutor.cs
@@ -86,7 +86,7 @@ namespace VirtualClient.Actions
                     // resiliency in the face of transient errors.
                     this.SetServerOnline(true);
 
-                    await webHostProcess.WaitAsync(cancellationToken)
+                    await webHostProcess.WaitForExitAsync(cancellationToken)
                         .ConfigureAwait(false);
                 }
 

--- a/src/VirtualClient/VirtualClient.Actions/FIO/FioDiscoveryExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/FIO/FioDiscoveryExecutor.cs
@@ -264,9 +264,9 @@ namespace VirtualClient.Actions
                                                 [nameof(filePath).CamelCased()] = filePath
                                             };
 
-                                            this.WorkloadProcesses.Clear();
                                             await fioDiscoveryRetryPolicy.ExecuteAsync(async () =>
                                             {
+                                                this.WorkloadProcesses.Clear();
                                                 this.WorkloadProcesses.AddRange(this.CreateWorkloadProcesses(this.ExecutablePath, commandLine, disksToTest, this.ProcessModel));
 
                                                 foreach (DiskPerformanceWorkloadProcess process in this.WorkloadProcesses)

--- a/src/VirtualClient/VirtualClient.Actions/Memcached/MemcachedServerExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Memcached/MemcachedServerExecutor.cs
@@ -90,7 +90,7 @@ namespace VirtualClient.Actions
                                 foreach (IProcessProxy process in memcachedProcessProxyList)
                                 {
                                     this.CleanupTasks.Add(() => process.SafeKill());
-                                    await process.WaitAsync(cancellationToken)
+                                    await process.WaitForExitAsync(cancellationToken)
                                         .ConfigureAwait(false);
                                 }
                             }

--- a/src/VirtualClient/VirtualClient.Actions/Redis/RedisServerExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Redis/RedisServerExecutor.cs
@@ -89,7 +89,7 @@ namespace VirtualClient.Actions
                                 foreach (IProcessProxy process in processProxyList)
                                 {
                                     this.CleanupTasks.Add(() => process.SafeKill());
-                                    await process.WaitAsync(cancellationToken)
+                                    await process.WaitForExitAsync(cancellationToken)
                                         .ConfigureAwait(false);
                                 }
                             }

--- a/src/VirtualClient/VirtualClient.Actions/SysbenchOLTP/SysbenchOLTPServerExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/SysbenchOLTP/SysbenchOLTPServerExecutor.cs
@@ -80,7 +80,7 @@ namespace VirtualClient.Actions
                                 foreach (IProcessProxy process in processProxyList)
                                 {
                                     this.CleanupTasks.Add(() => process.SafeKill());
-                                    await process.WaitAsync(cancellationToken)
+                                    await process.WaitForExitAsync(cancellationToken)
                                         .ConfigureAwait(false);
                                 }
                             }

--- a/src/VirtualClient/VirtualClient.Common/Process/IProcessProxy.cs
+++ b/src/VirtualClient/VirtualClient.Common/Process/IProcessProxy.cs
@@ -8,6 +8,8 @@ namespace VirtualClient.Common
     using System.Diagnostics;
     using System.IO;
     using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Acts as a limited proxy to provide information about a process running
@@ -99,6 +101,16 @@ namespace VirtualClient.Common
         /// Starts the underlying process.
         /// </summary>
         bool Start();
+
+        /// <summary>
+        /// Wait for process to exit.
+        /// </summary>
+        /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
+        /// <param name="timeout">
+        /// An absolute timeout to apply for the case that the process does not finish in the amount of time expected. If the
+        /// timeout is reached a <see cref="TimeoutException"/> exception will be thrown.
+        /// </param>
+        Task WaitForExitAsync(CancellationToken cancellationToken, TimeSpan? timeout = null);
 
         /// <summary>
         /// Writes input to the standard input stream.

--- a/src/VirtualClient/VirtualClient.Common/Process/ProcessExecutionExtensions.cs
+++ b/src/VirtualClient/VirtualClient.Common/Process/ProcessExecutionExtensions.cs
@@ -63,7 +63,7 @@ namespace VirtualClient.Common
 
             if (process.Start())
             {
-                await process.WaitAsync(cancellationToken, timeout).ConfigureAwait(false);
+                await process.WaitForExitAsync(cancellationToken, timeout).ConfigureAwait(false);
             }
         }
 
@@ -87,44 +87,6 @@ namespace VirtualClient.Common
                     throw new MissingMethodException(
                         $"The exception type provided '{typeof(TError).FullName}' does not have a constructor that takes in a single 'message' parameter.");
                 }
-            }
-        }
-
-        /// <summary>
-        /// Starts the underlying process and monitors it for completion.
-        /// </summary>
-        /// <param name="process">Represents a process on the system.</param>
-        /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
-        /// <param name="timeout">
-        /// An absolute timeout to apply for the case that the process does not finish in the amount of time expected. If the
-        /// timeout is reached a <see cref="TimeoutException"/> exception will be thrown.
-        /// </param>
-        public static async Task WaitAsync(this IProcessProxy process, CancellationToken cancellationToken, TimeSpan? timeout = null)
-        {
-            process.ThrowIfNull(nameof(process));
-
-            DateTime startTime = DateTime.Now;
-            DateTime endTime = DateTime.MaxValue;
-            if (timeout != null)
-            {
-                endTime = startTime.Add(timeout.Value);
-            }
-
-            while (!process.HasExited)
-            {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    break;
-                }
-
-                if (timeout != null && DateTime.Now > endTime)
-                {
-                    throw new TimeoutException(
-                        $"The process did not complete within the specified timeout " +
-                        $"(timeout={timeout.ToString()}, command={process.StartInfo.FileName} {process.StartInfo.Arguments}).");
-                }
-
-                await Task.Delay(10).ConfigureAwait(false);
             }
         }
 

--- a/src/VirtualClient/VirtualClient.Common/Process/ProcessProxy.cs
+++ b/src/VirtualClient/VirtualClient.Common/Process/ProcessProxy.cs
@@ -8,6 +8,8 @@ namespace VirtualClient.Common
     using System.Collections.Specialized;
     using System.Diagnostics;
     using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
     using VirtualClient.Common.Extensions;
 
     /// <summary>
@@ -204,18 +206,27 @@ namespace VirtualClient.Common
         /// <inheritdoc />
         public virtual bool Start()
         {
+            if (this.RedirectStandardError)
+            {
+                this.UnderlyingProcess.ErrorDataReceived += this.OnStandardErrorReceived;
+            }
+
+            if (this.RedirectStandardOutput)
+            {
+                this.UnderlyingProcess.OutputDataReceived += this.OnStandardOutputReceived;
+            }
+
             bool processStarted = this.UnderlyingProcess.Start();
+
             if (processStarted)
             {
                 if (this.RedirectStandardError)
                 {
-                    this.UnderlyingProcess.ErrorDataReceived += this.OnStandardErrorReceived;
                     this.UnderlyingProcess.BeginErrorReadLine();
                 }
 
                 if (this.RedirectStandardOutput)
                 {
-                    this.UnderlyingProcess.OutputDataReceived += this.OnStandardOutputReceived;
                     this.UnderlyingProcess.BeginOutputReadLine();
                 }
             }
@@ -238,6 +249,21 @@ namespace VirtualClient.Common
 
             this.StandardInput.WriteLine(input);
             return this;
+        }
+
+        /// <summary>
+        /// Wait for process to exit
+        /// </summary>
+        public virtual async Task WaitForExitAsync(CancellationToken cancellationToken, TimeSpan? timeout = null)
+        {
+            if (timeout == null)
+            {
+                await this.UnderlyingProcess.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await this.UnderlyingProcess.WaitForExitAsync(cancellationToken).WaitAsync(timeout.Value).ConfigureAwait(false);
+            }
         }
 
         /// <summary>

--- a/src/VirtualClient/VirtualClient.TestFramework/InMemoryProcess.cs
+++ b/src/VirtualClient/VirtualClient.TestFramework/InMemoryProcess.cs
@@ -10,6 +10,8 @@ namespace VirtualClient
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
     using VirtualClient.Common;
 
     /// <summary>
@@ -161,6 +163,11 @@ namespace VirtualClient
         {
             this.Executed = true;
             return this.OnStart?.Invoke() ?? true;
+        }
+
+        public Task WaitForExitAsync(CancellationToken cancellationToken, TimeSpan? timeout = null)
+        {
+            return Task.CompletedTask;
         }
 
         /// <summary>


### PR DESCRIPTION
We found that during FIO and workloads that outputs a large amount of text, sometimes outputs could be missing. We use the .NET process events for capturing outputs. We removed the previous implementation of checking the process exited status in the code and replaced it with the out-of-box WaitAsync provided by .NET.