### PR TITLE
Remove /mnt path as a ineligible IO path

### DIFF
--- a/.pipelines/azure-pipelines.yml
+++ b/.pipelines/azure-pipelines.yml
@@ -17,7 +17,7 @@ pool:
   vmImage: windows-latest
 
 variables:
-  VcVersion : 0.3.5
+  VcVersion : 0.3.6
   ROOT: $(Build.SourcesDirectory)
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   ENABLE_PRS_DELAYSIGN: 1

--- a/src/VirtualClient/VirtualClient.Contracts/DiskExtensions.cs
+++ b/src/VirtualClient/VirtualClient.Contracts/DiskExtensions.cs
@@ -33,7 +33,6 @@ namespace VirtualClient.Contracts
             string path = string.Empty;
             List<string> forbiddenPaths = new List<string>()
             {
-                "/mnt",
                 "/boot/efi"
             };
 
@@ -53,6 +52,12 @@ namespace VirtualClient.Contracts
             {
                 // If it is not OS disk, test on biggest partition that's not in forbidden path.
                 IEnumerable<DiskVolume> eligibleVolumes = disk.Volumes.Where(v => !v.AccessPaths.Any(p => forbiddenPaths.Contains(p.ToLower())));
+
+                if (eligibleVolumes.Count() == 0)
+                {
+                    throw new WorkloadException($"There is no eligible volume in {disk.DevicePath} that can run IO workloads.", ErrorReason.EnvironmentIsInsufficent);
+                }
+
                 long biggestSize = eligibleVolumes.Max(v => v.SizeInBytes(platform));
                 path = eligibleVolumes.Where(v => v.SizeInBytes(platform) == biggestSize).FirstOrDefault().AccessPaths.FirstOrDefault();
             }


### PR DESCRIPTION
/mnt path has been defined as non eligible for IO path, removing that restriction