### PR TITLE
Upgrading System.IO.Abstractions to version 19.1.5

### DIFF
--- a/src/VirtualClient/Module.props
+++ b/src/VirtualClient/Module.props
@@ -144,7 +144,7 @@
         <System_Diagnostics_PerformanceCounter_PackageVersion>6.0.0</System_Diagnostics_PerformanceCounter_PackageVersion>
 
         <!-- System.IO.Abstractions -->
-        <System_IO_Abstractions_PackageVersion>13.2.47</System_IO_Abstractions_PackageVersion>
+        <System_IO_Abstractions_PackageVersion>19.1.5</System_IO_Abstractions_PackageVersion>
 
         <!-- System.IO.FileSystem.AccessControl -->
         <System_IO_FileSystem_AccessControl_PackageVersion>5.0.0</System_IO_FileSystem_AccessControl_PackageVersion>

--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/SPEC/SpecCpuExecutorTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/SPEC/SpecCpuExecutorTests.cs
@@ -311,7 +311,7 @@ namespace VirtualClient.Actions
             string mockProfileText = File.ReadAllText(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "SPEC", "mockspeccpu.cfg"));
             this.mockFixture.File.Setup(f => f.ReadAllTextAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockProfileText);
             this.mockFixture.FileSystem.SetupGet(fs => fs.File).Returns(this.mockFixture.File.Object);
-            this.mockFixture.FileInfo.Setup(file => file.FromFileName(It.IsAny<string>()))
+            this.mockFixture.FileInfo.Setup(file => file.New(It.IsAny<string>()))
                 .Returns(new Mock<IFileInfo>().Object);
 
             this.mockFixture.Parameters = new Dictionary<string, IConvertible>()
@@ -341,7 +341,7 @@ namespace VirtualClient.Actions
             string mockProfileText = File.ReadAllText(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "SPEC", "mockspeccpu.cfg"));
             this.mockFixture.File.Setup(f => f.ReadAllTextAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockProfileText);
             this.mockFixture.FileSystem.SetupGet(fs => fs.File).Returns(this.mockFixture.File.Object);
-            this.mockFixture.FileInfo.Setup(file => file.FromFileName(It.IsAny<string>()))
+            this.mockFixture.FileInfo.Setup(file => file.New(It.IsAny<string>()))
                 .Returns(new Mock<IFileInfo>().Object);
 
             this.mockFixture.Parameters = new Dictionary<string, IConvertible>()

--- a/src/VirtualClient/VirtualClient.Actions/SPECcpu/SpecCpuExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/SPECcpu/SpecCpuExecutor.cs
@@ -334,7 +334,7 @@ namespace VirtualClient.Actions
 
                 if (outputFiles?.Any() == true)
                 {
-                    IEnumerable<IFileInfo> files = outputFiles.ToList().Select(path => this.fileSystem.FileInfo.FromFileName(path));
+                    IEnumerable<IFileInfo> files = outputFiles.ToList().Select(path => this.fileSystem.FileInfo.New(path));
 
                     IEnumerable<FileBlobDescriptor> blobDescriptors = FileBlobDescriptor.ToBlobDescriptors(
                         files,

--- a/src/VirtualClient/VirtualClient.Actions/SPECjbb/SpecJbbExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/SPECjbb/SpecJbbExecutor.cs
@@ -261,7 +261,7 @@ namespace VirtualClient.Actions
                 // Example Blob Store Structure:
                 // /7dfae74c-06c0-49fc-ade6-987534bb5169/anyagentid/specjbb/2022-04-30T20:13:23.3768938Z-gc.log
                 FileBlobDescriptor resultsBlob = FileBlobDescriptor.ToBlobDescriptor(
-                    this.fileSystem.FileInfo.FromFileName(gcLogPath),
+                    this.fileSystem.FileInfo.New(gcLogPath),
                     HttpContentType.PlainText,
                     this.ExperimentId,
                     this.AgentId,

--- a/src/VirtualClient/VirtualClient.Api.UnitTests/StateControllerTests.cs
+++ b/src/VirtualClient/VirtualClient.Api.UnitTests/StateControllerTests.cs
@@ -26,7 +26,7 @@ namespace VirtualClient.Api
     {
         private MockFixture mockFixture;
         private IConfiguration mockConfiguration;
-        private Mock<FileSystemStream> mockFileStream;
+        private Mock<InMemoryFileSystemStream> mockFileStream;
         private State mockState;
         private Item<JObject> mockStateInstance;
         private StateController controller;
@@ -36,7 +36,7 @@ namespace VirtualClient.Api
         {
             this.mockFixture = new MockFixture();
             this.mockConfiguration = new ConfigurationBuilder().Build();
-            this.mockFileStream = new Mock<FileSystemStream>();
+            this.mockFileStream = new Mock<InMemoryFileSystemStream>();
             this.mockState = new State(new Dictionary<string, IConvertible>
             {
                 ["property1"] = 1234

--- a/src/VirtualClient/VirtualClient.Api/StateController.cs
+++ b/src/VirtualClient/VirtualClient.Api/StateController.cs
@@ -150,7 +150,7 @@ namespace VirtualClient.Api
 
                     // The file cannot be access by anything else during the time it is being written to. This is purposeful
                     // to ensure consistency with read/write operations.
-                    using (Stream stream = this.FileSystem.FileStream.Create(stateFilePath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+                    using (Stream stream = this.FileSystem.FileStream.New(stateFilePath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
                     {
                         byte[] fileContent = Encoding.UTF8.GetBytes(stateInstance.ToJson(StateController.StateSerializationSettings));
                         await stream.WriteAsync(fileContent, 0, fileContent.Length);
@@ -366,7 +366,7 @@ namespace VirtualClient.Api
 
                         // The file cannot be access by anything else during the time it is being written to. This is purposeful
                         // to ensure consistency with read/write operations.
-                        using (Stream stream = this.FileSystem.FileStream.Create(stateFilePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None))
+                        using (Stream stream = this.FileSystem.FileStream.New(stateFilePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None))
                         {
                             byte[] fileContent = Encoding.UTF8.GetBytes(state.ToJson(StateController.StateSerializationSettings));
                             stream.SetLength(0);

--- a/src/VirtualClient/VirtualClient.Dependencies.UnitTests/CUDAAndNvidiaGPUDriverInstallationTests.cs
+++ b/src/VirtualClient/VirtualClient.Dependencies.UnitTests/CUDAAndNvidiaGPUDriverInstallationTests.cs
@@ -138,7 +138,7 @@ namespace VirtualClient.Dependencies
                 .Returns(true);
 
             this.fixture.FileSystem.Setup(fe => fe.FileStream.New(It.IsAny<string>(), FileMode.Create, FileAccess.Write, FileShare.None))
-                .Returns(new Mock<FileSystemStream>().Object);
+                .Returns(new Mock<InMemoryFileSystemStream>().Object);
 
             this.fixture.FileSystem.Setup(fe => fe.Directory.GetFiles(It.IsAny<string>(), It.IsAny<string>(), SearchOption.AllDirectories))
                 .Returns(new string[] { this.fixture.Combine(this.mockPackage.Path, "nvidiaDriversInstaller.exe") });

--- a/src/VirtualClient/VirtualClient.Dependencies.UnitTests/CUDAAndNvidiaGPUDriverInstallationTests.cs
+++ b/src/VirtualClient/VirtualClient.Dependencies.UnitTests/CUDAAndNvidiaGPUDriverInstallationTests.cs
@@ -7,6 +7,7 @@ namespace VirtualClient.Dependencies
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
+    using System.IO.Abstractions;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -136,8 +137,8 @@ namespace VirtualClient.Dependencies
             this.fixture.Directory.Setup(di => di.Exists(It.IsAny<string>()))
                 .Returns(true);
 
-            this.fixture.FileSystem.Setup(fe => fe.FileStream.Create(It.IsAny<string>(), FileMode.Create, FileAccess.Write, FileShare.None))
-                .Returns(Stream.Null);
+            this.fixture.FileSystem.Setup(fe => fe.FileStream.New(It.IsAny<string>(), FileMode.Create, FileAccess.Write, FileShare.None))
+                .Returns(new Mock<FileSystemStream>().Object);
 
             this.fixture.FileSystem.Setup(fe => fe.Directory.GetFiles(It.IsAny<string>(), It.IsAny<string>(), SearchOption.AllDirectories))
                 .Returns(new string[] { this.fixture.Combine(this.mockPackage.Path, "nvidiaDriversInstaller.exe") });

--- a/src/VirtualClient/VirtualClient.Examples/ExampleMonitorWithBlobUploadIntegration.cs
+++ b/src/VirtualClient/VirtualClient.Examples/ExampleMonitorWithBlobUploadIntegration.cs
@@ -157,7 +157,7 @@ namespace VirtualClient
                 //            555553ed-3f63-43fe-ae7c-327bae09ee60/cluster01,cc296787-aee6-4ce4-b814-180627508d12,anyvm-01/example_monitor/2021-11-19T13:46:30.6489302Z-monitor.log
                 //            555553ed-3f63-43fe-ae7c-327bae09ee60/cluster01,cc296787-aee6-4ce4-b814-180627508d12,anyvm-01/example_monitor/2021-11-19T13:47:32.7295123Z-monitor.log
                 FileBlobDescriptor resultsBlob = FileBlobDescriptor.ToBlobDescriptor(
-                    this.fileSystem.FileInfo.FromFileName(resultsFilePath),
+                    this.fileSystem.FileInfo.New(resultsFilePath),
                     this.ExperimentId,
                     this.AgentId,
                     "examplemonitor");

--- a/src/VirtualClient/VirtualClient.TestFramework/InMemoryDirectoryInfo.cs
+++ b/src/VirtualClient/VirtualClient.TestFramework/InMemoryDirectoryInfo.cs
@@ -235,6 +235,8 @@ namespace VirtualClient
         /// <inheritdoc />
         public string Name { get; }
 
+        public string LinkTarget { get; }
+
         /// <inheritdoc />
         public void Create()
         {
@@ -245,6 +247,11 @@ namespace VirtualClient
         public void Create(DirectorySecurity directorySecurity)
         {
             (this.FileSystem as InMemoryFileSystem).AddOrGetDirectory(this.FullName);
+        }
+
+        public void CreateAsSymbolicLink(string pathToTarget)
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -490,6 +497,11 @@ namespace VirtualClient
         /// Not Implemented
         /// </summary>
         public void Refresh()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IFileSystemInfo ResolveLinkTarget(bool returnFinalTarget)
         {
             throw new NotImplementedException();
         }

--- a/src/VirtualClient/VirtualClient.TestFramework/InMemoryDirectoryIntegration.cs
+++ b/src/VirtualClient/VirtualClient.TestFramework/InMemoryDirectoryIntegration.cs
@@ -55,6 +55,11 @@ namespace VirtualClient
             return this.CreateDirectory(path);
         }
 
+        public IFileSystemInfo CreateSymbolicLink(string path, string pathToTarget)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <inheritdoc />
         public void Delete(string path)
         {
@@ -304,6 +309,16 @@ namespace VirtualClient
             throw new NotImplementedException();
         }
 
+        public string[] GetFileSystemEntries(string path, string searchPattern, SearchOption searchOption)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string[] GetFileSystemEntries(string path, string searchPattern, EnumerationOptions enumerationOptions)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Not implemented.
         /// </summary>
@@ -354,6 +369,11 @@ namespace VirtualClient
         /// Not implemented.
         /// </summary>
         public void Move(string sourceDirName, string destDirName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IFileSystemInfo ResolveLinkTarget(string linkPath, bool returnFinalTarget)
         {
             throw new NotImplementedException();
         }

--- a/src/VirtualClient/VirtualClient.TestFramework/InMemoryFileIntegration.cs
+++ b/src/VirtualClient/VirtualClient.TestFramework/InMemoryFileIntegration.cs
@@ -135,25 +135,25 @@ namespace VirtualClient
         }
 
         /// <inheritdoc />
-        public Stream Create(string path)
+        public FileSystemStream Create(string path)
         {
-            Stream stream = this.Open(path, FileMode.CreateNew);
+            FileSystemStream stream = this.Open(path, FileMode.CreateNew);
             (this.FileSystem as InMemoryFileSystem).OnCreateFile?.Invoke(path);
             return stream;
         }
 
         /// <inheritdoc />
-        public Stream Create(string path, int bufferSize)
+        public FileSystemStream Create(string path, int bufferSize)
         {
-            Stream stream = this.Open(path, FileMode.CreateNew);
+            FileSystemStream stream = this.Open(path, FileMode.CreateNew);
             (this.FileSystem as InMemoryFileSystem).OnCreateFile?.Invoke(path);
             return stream;
         }
 
         /// <inheritdoc />
-        public Stream Create(string path, int bufferSize, FileOptions options)
+        public FileSystemStream Create(string path, int bufferSize, FileOptions options)
         {
-            Stream stream = this.Open(path, FileMode.CreateNew);
+            FileSystemStream stream = this.Open(path, FileMode.CreateNew);
             (this.FileSystem as InMemoryFileSystem).OnCreateFile?.Invoke(path);
             return stream;
         }
@@ -276,19 +276,19 @@ namespace VirtualClient
         }
 
         /// <inheritdoc />
-        public Stream Open(string path, FileMode mode)
+        public FileSystemStream Open(string path, FileMode mode)
         {
             return this.Open(path, mode, FileAccess.ReadWrite, FileShare.ReadWrite);
         }
 
         /// <inheritdoc />
-        public Stream Open(string path, FileMode mode, FileAccess access)
+        public FileSystemStream Open(string path, FileMode mode, FileAccess access)
         {
             return this.Open(path, mode, access, FileShare.ReadWrite);
         }
 
         /// <inheritdoc />
-        public Stream Open(string path, FileMode mode, FileAccess access, FileShare share)
+        public FileSystemStream Open(string path, FileMode mode, FileAccess access, FileShare share)
         {
             InMemoryFile file = null;
 
@@ -326,7 +326,8 @@ namespace VirtualClient
             }
 
             (this.FileSystem as InMemoryFileSystem).OnReadFile?.Invoke(path);
-            return new MemoryStream(file.FileBytes.ToArray());
+            
+            return new InMemoryFileSystemStream(new MemoryStream(file.FileBytes.ToArray()), path, false);
         }
 
         public FileSystemStream Open(string path, FileStreamOptions options)
@@ -335,7 +336,7 @@ namespace VirtualClient
         }
 
         /// <inheritdoc />
-        public Stream OpenRead(string path)
+        public FileSystemStream OpenRead(string path)
         {
             return this.Open(path, FileMode.Open);
         }
@@ -347,7 +348,7 @@ namespace VirtualClient
         }
 
         /// <inheritdoc />
-        public Stream OpenWrite(string path)
+        public FileSystemStream OpenWrite(string path)
         {
             return this.Open(path, FileMode.OpenOrCreate);
         }
@@ -593,46 +594,6 @@ namespace VirtualClient
         {
             this.WriteAllText(path, contents, encoding);
             return Task.CompletedTask;
-        }
-
-        FileSystemStream IFile.Create(string path)
-        {
-            throw new NotImplementedException();
-        }
-
-        FileSystemStream IFile.Create(string path, int bufferSize)
-        {
-            throw new NotImplementedException();
-        }
-
-        FileSystemStream IFile.Create(string path, int bufferSize, FileOptions options)
-        {
-            throw new NotImplementedException();
-        }
-
-        FileSystemStream IFile.Open(string path, FileMode mode)
-        {
-            throw new NotImplementedException();
-        }
-
-        FileSystemStream IFile.Open(string path, FileMode mode, FileAccess access)
-        {
-            throw new NotImplementedException();
-        }
-
-        FileSystemStream IFile.Open(string path, FileMode mode, FileAccess access, FileShare share)
-        {
-            throw new NotImplementedException();
-        }
-
-        FileSystemStream IFile.OpenRead(string path)
-        {
-            throw new NotImplementedException();
-        }
-
-        FileSystemStream IFile.OpenWrite(string path)
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/src/VirtualClient/VirtualClient.TestFramework/InMemoryFileIntegration.cs
+++ b/src/VirtualClient/VirtualClient.TestFramework/InMemoryFileIntegration.cs
@@ -158,6 +158,11 @@ namespace VirtualClient
             return stream;
         }
 
+        public IFileSystemInfo CreateSymbolicLink(string path, string pathToTarget)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <inheritdoc />
         public StreamWriter CreateText(string path)
         {
@@ -324,6 +329,11 @@ namespace VirtualClient
             return new MemoryStream(file.FileBytes.ToArray());
         }
 
+        public FileSystemStream Open(string path, FileStreamOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <inheritdoc />
         public Stream OpenRead(string path)
         {
@@ -432,6 +442,11 @@ namespace VirtualClient
         /// Not implemented.
         /// </summary>
         public void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IFileSystemInfo ResolveLinkTarget(string linkPath, bool returnFinalTarget)
         {
             throw new NotImplementedException();
         }
@@ -578,6 +593,46 @@ namespace VirtualClient
         {
             this.WriteAllText(path, contents, encoding);
             return Task.CompletedTask;
+        }
+
+        FileSystemStream IFile.Create(string path)
+        {
+            throw new NotImplementedException();
+        }
+
+        FileSystemStream IFile.Create(string path, int bufferSize)
+        {
+            throw new NotImplementedException();
+        }
+
+        FileSystemStream IFile.Create(string path, int bufferSize, FileOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        FileSystemStream IFile.Open(string path, FileMode mode)
+        {
+            throw new NotImplementedException();
+        }
+
+        FileSystemStream IFile.Open(string path, FileMode mode, FileAccess access)
+        {
+            throw new NotImplementedException();
+        }
+
+        FileSystemStream IFile.Open(string path, FileMode mode, FileAccess access, FileShare share)
+        {
+            throw new NotImplementedException();
+        }
+
+        FileSystemStream IFile.OpenRead(string path)
+        {
+            throw new NotImplementedException();
+        }
+
+        FileSystemStream IFile.OpenWrite(string path)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/VirtualClient/VirtualClient.TestFramework/InMemoryFileSystemStream.cs
+++ b/src/VirtualClient/VirtualClient.TestFramework/InMemoryFileSystemStream.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace VirtualClient
+{
+    using System.IO;
+    using System.IO.Abstractions;
+
+    /// <summary>
+    /// Concrete implementation of <see cref="FileSystemStream"/> that wraps the <see cref="FileStream"/>.
+    /// </summary>
+    public class InMemoryFileSystemStream : FileSystemStream
+    {
+        public InMemoryFileSystemStream()
+            : base(new MemoryStream(), "fakepath", false)
+        {
+        }
+
+        public InMemoryFileSystemStream(Stream stream, string path, bool isAsync) 
+            : base(stream, path, isAsync)
+        {
+        }
+    }
+}

--- a/src/VirtualClient/VirtualClient.TestFramework/VirtualClient.TestFramework.csproj
+++ b/src/VirtualClient/VirtualClient.TestFramework/VirtualClient.TestFramework.csproj
@@ -11,6 +11,7 @@
         <!-- Global package dependency versions are defined in the Module.props for the solution. -->
         <PackageReference Include="AutoFixture" Version="$(AutoFixture_PackageVersion)" />
         <PackageReference Include="Moq" Version="$(Moq_PackageVersion)" />
+        <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="19.1.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/VirtualClient/VirtualClient.TestFramework/VirtualClient.TestFramework.csproj
+++ b/src/VirtualClient/VirtualClient.TestFramework/VirtualClient.TestFramework.csproj
@@ -11,7 +11,6 @@
         <!-- Global package dependency versions are defined in the Module.props for the solution. -->
         <PackageReference Include="AutoFixture" Version="$(AutoFixture_PackageVersion)" />
         <PackageReference Include="Moq" Version="$(Moq_PackageVersion)" />
-        <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="19.1.5" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
I'm consuming the VirtualClient.Framework package in a downstream project that requires the minimum version of System.IO.Abstractions to be 19.1.5
