### PR TITLE
Making the GlobalParameters Static for access to child classes in Client-server workloads

### DIFF
--- a/src/VirtualClient/VirtualClient.Contracts/VirtualClientComponent.cs
+++ b/src/VirtualClient/VirtualClient.Contracts/VirtualClientComponent.cs
@@ -60,7 +60,6 @@ namespace VirtualClient.Contracts
             }
 
             this.Metadata = new Dictionary<string, IConvertible>(StringComparer.OrdinalIgnoreCase);
-            this.GlobalParameters = new Dictionary<string, IConvertible>(StringComparer.OrdinalIgnoreCase);
             this.Dependencies = dependencies;
             this.Logger = NullLogger.Instance;
 
@@ -126,7 +125,7 @@ namespace VirtualClient.Contracts
         {
             get
             {
-                return this.GlobalParameters.GetValue<string>(nameof(this.ContentPathTemplate), "{experimentId}/{agentId}/{toolName}/{role}/{scenario}");
+                return VirtualClientComponent.GlobalParameters.GetValue<string>(nameof(this.ContentPathTemplate), "{experimentId}/{agentId}/{toolName}/{role}/{scenario}");
             }
         }
 
@@ -159,7 +158,7 @@ namespace VirtualClient.Contracts
         /// <summary>
         /// Global Parameters provided to the application on the command line or through Parameters in respective profiles.
         /// </summary>
-        public IDictionary<string, IConvertible> GlobalParameters { get; }
+        public static IDictionary<string, IConvertible> GlobalParameters { get; } = new Dictionary<string, IConvertible>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// The client environment/topology layout provided to the Virtual Client application.

--- a/src/VirtualClient/VirtualClient.Contracts/VirtualClientComponentExtensions.cs
+++ b/src/VirtualClient/VirtualClient.Contracts/VirtualClientComponentExtensions.cs
@@ -117,7 +117,7 @@ namespace VirtualClient.Contracts
                 appendedMetaData.AddRange(metadata, true);
             }
 
-            IDictionary<string, IConvertible> appendedParameters = new Dictionary<string, IConvertible>(component.GlobalParameters, StringComparer.OrdinalIgnoreCase);
+            IDictionary<string, IConvertible> appendedParameters = new Dictionary<string, IConvertible>(VirtualClientComponent.GlobalParameters, StringComparer.OrdinalIgnoreCase);
             if (!(parameters is null))
             {
                 appendedParameters.AddRange(parameters, true);

--- a/src/VirtualClient/VirtualClient.Core/ProfileExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Core/ProfileExecutor.cs
@@ -710,7 +710,7 @@ namespace VirtualClient
 
                         if (this.Profile.Parameters?.Any() == true)
                         {
-                            runtimeComponent.GlobalParameters.AddRange(this.Profile.Parameters, true);
+                            VirtualClientComponent.GlobalParameters.AddRange(this.Profile.Parameters, true);
                         }
 
                         if (!VirtualClientComponent.IsSupported(runtimeComponent))


### PR DESCRIPTION
This PR is for Client Server workloads. In Client Server workloads, a common executor calls the client and server class by declaring objects and just passing the dependencies and component Parameters. So, the client/server executors do not have visibility to GlobalParameters.

Making the GlobalParameters a static component as they are expected to be common across all components (unlike component level parameters)