### PR TITLE
Adding support for creating multiple files on a disk for DiskSpd work…

### DIFF
--- a/.pipelines/azure-pipelines-linux.yml
+++ b/.pipelines/azure-pipelines-linux.yml
@@ -13,7 +13,7 @@ pool:
   vmImage: ubuntu-latest
 
 variables:
-  VcVersion : 1.9.0
+  VcVersion : 1.9.1
   ROOT: $(Build.SourcesDirectory)
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   ENABLE_PRS_DELAYSIGN: 1

--- a/.pipelines/azure-pipelines.yml
+++ b/.pipelines/azure-pipelines.yml
@@ -18,7 +18,7 @@ pool:
   vmImage: windows-latest
 
 variables:
-  VcVersion : 1.9.0
+  VcVersion : 1.9.1
   ROOT: $(Build.SourcesDirectory)
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   ENABLE_PRS_DELAYSIGN: 1

--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/DiskWorkloadExecutorTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/DiskWorkloadExecutorTests.cs
@@ -84,6 +84,19 @@ namespace VirtualClient.Actions.DiskPerformance
         }
 
         [Test]
+        public void DiskWorkloadExecutorCreatesExpectdTestFilesStringSeperatedByWhitespace()
+        {
+            this.profileParameters[nameof(DiskWorkloadExecutor.FileName)] = "test-1.dat, test-2.dat, test-3.dat";
+
+            using (TestDiskWorkloadExecutor workloadExecutor = new TestDiskWorkloadExecutor(this.mockFixture.Dependencies, this.profileParameters))
+            {
+                string testFilesSeperatedByWhitesapce = workloadExecutor.GetTestFiles("D:\\any\\");
+                IEnumerable<string> testFiles = testFilesSeperatedByWhitesapce.Split(" ");
+                Assert.AreEqual(3, testFiles.Count());
+            }
+        }
+
+        [Test]
         public void DiskWorkloadExecutorCreatesTheExpectedProcessesInTheSingleProcessModel_RemoteDiskScenario()
         {
             string expectedCommand = "/home/any/path/to/fio";
@@ -243,6 +256,11 @@ namespace VirtualClient.Actions.DiskPerformance
             public new IEnumerable<Disk> GetDisksToTest(IEnumerable<Disk> disks)
             {
                 return base.GetDisksToTest(disks);
+            }
+
+            public new string GetTestFiles(string mountPoint)
+            {
+                return base.GetTestFiles(mountPoint);
             }
 
             protected override Task<bool> CreateMountPointsAsync(IEnumerable<Disk> disks, CancellationToken cancellationToken)

--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/DiskWorkloadExecutorTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/DiskWorkloadExecutorTests.cs
@@ -87,12 +87,16 @@ namespace VirtualClient.Actions.DiskPerformance
         public void DiskWorkloadExecutorCreatesExpectdTestFilesStringSeperatedByWhitespace()
         {
             this.profileParameters[nameof(DiskWorkloadExecutor.FileName)] = "test-1.dat, test-2.dat, test-3.dat";
+            string mountPoint = "D:\\any\\";
+
+            string expectedTestFilesSeperatedByWhitesapce = "D:/any/test-1.dat D:/any/test-2.dat D:/any/test-3.dat";
 
             using (TestDiskWorkloadExecutor workloadExecutor = new TestDiskWorkloadExecutor(this.mockFixture.Dependencies, this.profileParameters))
             {
-                string testFilesSeperatedByWhitesapce = workloadExecutor.GetTestFiles("D:\\any\\");
+                string testFilesSeperatedByWhitesapce = workloadExecutor.GetTestFiles(mountPoint);
                 IEnumerable<string> testFiles = testFilesSeperatedByWhitesapce.Split(" ");
                 Assert.AreEqual(3, testFiles.Count());
+                Assert.AreEqual(expectedTestFilesSeperatedByWhitesapce, testFilesSeperatedByWhitesapce);
             }
         }
 

--- a/src/VirtualClient/VirtualClient.Actions/DiskSpd/DiskSpdExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/DiskSpd/DiskSpdExecutor.cs
@@ -284,7 +284,7 @@ namespace VirtualClient.Actions
         /// <param name="disksToTest">The disks under test.</param>
         protected override DiskWorkloadProcess CreateWorkloadProcess(string executable, string commandArguments, string testedInstance, params Disk[] disksToTest)
         {
-            string[] testFiles = disksToTest.Select(disk => this.GetTestFile(disk.GetPreferredAccessPath(this.Platform))).ToArray();
+            string[] testFiles = disksToTest.Select(disk => this.GetTestFiles(disk.GetPreferredAccessPath(this.Platform))).ToArray();
             string diskSpdArguments = $"{commandArguments} {string.Join(" ", testFiles)}";
 
             IProcessProxy process = this.SystemManagement.ProcessManager.CreateProcess(executable, diskSpdArguments);


### PR DESCRIPTION
Adding support for creating multiple files on a disk for DiskSpd workloads. Multiple file names can be specified through the parameter "FileName" of the DiskSpdExecutor.
e.g., For creating three files on a Disk, three file names are provided in the "FileName" parameter.
"Type": "DiskSpdExecutor",
"Parameters": {
    "Scenario": "...",
    "CommandLine": "...",
    "TestName": "DiskSpd_Test",
    "FileName": "diskspd-test-1.dat, diskspd-test-2.dat, diskspd-test-3.dat"
}