### PR TITLE
standardizing 'toolname' and 'scenarioname' for db workloads

### DIFF
--- a/src/VirtualClient/VirtualClient.Actions/PostgreSQL/PostgreSQLExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/PostgreSQL/PostgreSQLExecutor.cs
@@ -235,8 +235,8 @@ namespace VirtualClient.Actions
             if (results != null)
             {
                 this.Logger.LogMetrics(
-                    "PostgreSQL",
-                    "TPC-C",
+                    "PostgreSQL-HammerDB",
+                    "TPC-C" + this.Scenario,
                     startTime,
                     endTime,
                     results.ToList(),

--- a/src/VirtualClient/VirtualClient.Actions/SysbenchOLTP/SysbenchOLTPClientExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/SysbenchOLTP/SysbenchOLTPClientExecutor.cs
@@ -256,7 +256,7 @@ namespace VirtualClient.Actions
                         IList<Metric> metrics = parser.Parse();
 
                         this.Logger.LogMetrics(
-                            toolName: "Sysbench",
+                            toolName: "MySQL-Sysbench",
                             scenarioName: "OLTP " + this.Scenario,
                             process.StartTime,
                             process.ExitTime,


### PR DESCRIPTION
ideas for standardizing how we log 'toolname' & 'scenarioname' in sql benchmarks