### PR TITLE
Updating all thrrows of platform and arch to logging

### DIFF
--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/Graph500/Graph500ExecutorTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/Graph500/Graph500ExecutorTests.cs
@@ -95,24 +95,6 @@ namespace VirtualClient.Actions
         }
 
         [Test]
-        [TestCase(PlatformID.Win32NT, Architecture.X64)]
-        [TestCase(PlatformID.Win32NT, Architecture.Arm64)]
-        public void Graph500ExecutorThrowsWhenPlatformIsNotSupported(PlatformID platformID, Architecture architecture)
-        {
-            this.fixture.Setup(platformID, architecture);
-            using (TestGraph500Executor executor = new TestGraph500Executor(this.fixture))
-            {
-                WorkloadException exception = Assert.ThrowsAsync<WorkloadException>(
-                    () => executor.ExecuteAsync(EventContext.None, CancellationToken.None));
-
-                if (platformID == PlatformID.Win32NT)
-                {
-                    Assert.AreEqual(ErrorReason.PlatformNotSupported, exception.Reason);
-                }
-            }
-        }
-
-        [Test]
         public async Task Graph500ExecutorLogsTheExpectedWorkloadMetrics()
         {
             this.SetupDefaultMockBehavior();

--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/HPLinpack/HPLinpackExecutorTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/HPLinpack/HPLinpackExecutorTests.cs
@@ -151,24 +151,6 @@ namespace VirtualClient.Actions
             }
         }
 
-        [Test]
-        [TestCase(PlatformID.Win32NT, Architecture.X64)]
-        [TestCase(PlatformID.Win32NT, Architecture.Arm64)]
-        public void HPLinpackExecutorThrowsWhenPlatformIsNotSupported(PlatformID platformID, Architecture architecture)
-        {
-            this.fixture.Setup(platformID, architecture);
-            using (TestHPLExecutor executor = new TestHPLExecutor(this.fixture))
-            {
-                WorkloadException exception = Assert.ThrowsAsync<WorkloadException>(
-                    () => executor.ExecuteAsync(EventContext.None, CancellationToken.None));
-
-                if (platformID == PlatformID.Win32NT)
-                {
-                    Assert.AreEqual(ErrorReason.PlatformNotSupported, exception.Reason);
-                }
-            }
-        }
-
         private void SetupDefaultMockBehavior(PlatformID platform = PlatformID.Unix, Architecture architecture = Architecture.X64)
         {
             this.fixture.Setup(platform, architecture);

--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/MLPerf/MLPerfExecutorTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/MLPerf/MLPerfExecutorTests.cs
@@ -36,18 +36,6 @@ namespace VirtualClient.Actions
         }
 
         [Test]
-        public void MLPerfExecutorThrowsOnUnsupportedPlatform()
-        {
-            this.SetupDefaultMockBehavior(PlatformID.Win32NT);
-
-            using (TestMLPerfExecutor MLPerfExecutor = new TestMLPerfExecutor(this.mockFixture.Dependencies, this.mockFixture.Parameters))
-            {
-                var workloadException = Assert.ThrowsAsync<WorkloadException>(() => MLPerfExecutor.ExecuteAsync(CancellationToken.None));
-                Assert.IsTrue(workloadException.Reason == ErrorReason.PlatformNotSupported);
-            }
-        }
-
-        [Test]
         public void MLPerfExecutorThrowsOnUnsupportedLinuxDistro()
         {
             this.SetupDefaultMockBehavior(PlatformID.Unix);

--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/Memcached/MemcachedExecutorTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/Memcached/MemcachedExecutorTests.cs
@@ -50,20 +50,6 @@ namespace VirtualClient.Actions
         }
 
         [Test]
-        public void MemcachedMemtierExecutorThrowsOnUnsupportedPlatformAsync()
-        {
-            this.SetupDefaultMockBehavior(PlatformID.Win32NT);
-
-            using (var memcachedMemtierExecutor = new TestMemcachedMemtierExecutor(this.fixture.Dependencies, this.fixture.Parameters))
-            {
-                WorkloadException exception = Assert.ThrowsAsync<WorkloadException>(
-                    () => memcachedMemtierExecutor.ExecuteAsync(CancellationToken.None));
-
-                Assert.AreEqual(ErrorReason.PlatformNotSupported, exception.Reason);
-            }
-        }
-
-        [Test]
         public void MemcachedMemtierExecutorThrowsOnUnsupportedDistroAsync()
         {
             this.SetupDefaultMockBehavior(PlatformID.Unix);

--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/NASParallelBench/NASParallelBenchExecutorTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/NASParallelBench/NASParallelBenchExecutorTests.cs
@@ -36,19 +36,6 @@ namespace VirtualClient.Actions
             this.SetupDefaultMockBehavior(PlatformID.Unix);
         }
 
-
-        [Test]
-        public void NASParallelBenchExecutorThrowsOnUnsupportedPlatform()
-        {
-            this.SetupDefaultMockBehavior(PlatformID.Win32NT);
-
-            using (TestNASParallelBenchExecutor NASParallelBenchExecutor = new TestNASParallelBenchExecutor(this.fixture.Dependencies, this.fixture.Parameters))
-            {
-                var workloadException = Assert.ThrowsAsync<WorkloadException>(() => NASParallelBenchExecutor.ExecuteAsync(CancellationToken.None));
-                Assert.IsTrue(workloadException.Reason == ErrorReason.PlatformNotSupported);
-            }
-        }
-
         [Test]
         public void NASParallelBenchExecutorThrowsOnUnsupportedLinuxDistro()
         {

--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/OpenFOAM/OpenFOAMExecutorTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/OpenFOAM/OpenFOAMExecutorTests.cs
@@ -38,28 +38,6 @@ namespace VirtualClient.Actions
         }
 
         [Test]
-        [TestCase(PlatformID.Win32NT, Architecture.X64)]
-        [TestCase(PlatformID.Win32NT, Architecture.Arm64)]
-        public void OpenFOAMExecutorThrowsWhenPlatformOrArchitectureIsNotSupported(PlatformID platformID, Architecture architecture)
-        {
-            this.SetupDefaultMockBehavior(platformID, architecture);
-            using (TestOpenFOAMExecutor executor = new TestOpenFOAMExecutor(this.fixture))
-            {
-                WorkloadException exception = Assert.ThrowsAsync<WorkloadException>(
-                    () => executor.ExecuteAsync(EventContext.None, CancellationToken.None));
-
-                if (platformID == PlatformID.Win32NT)
-                {
-                    Assert.AreEqual(ErrorReason.PlatformNotSupported, exception.Reason);
-                }
-                else
-                {
-                    Assert.AreEqual(ErrorReason.ProcessorArchitectureNotSupported, exception.Reason);
-                } 
-            }
-        }
-
-        [Test]
         [TestCase(PlatformID.Unix, Architecture.X64)]
         [TestCase(PlatformID.Unix, Architecture.Arm64)]
         public async Task OpenFOAMExecutorInitializesItsDependenciesAsExpected(PlatformID platformID, Architecture architecture)

--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/Redis/RedisExecutorTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/Redis/RedisExecutorTests.cs
@@ -48,18 +48,6 @@ namespace VirtualClient.Actions
         }
 
         [Test]
-        public void RedisExecutorThrowsOnUnsupportedPlatformAsync()
-        {
-            this.SetupDefaultMockBehavior(PlatformID.Win32NT);
-
-            using (var executor = new TestRedisExecutorExecutor(this.fixture.Dependencies, this.fixture.Parameters))
-            {
-                WorkloadException exception = Assert.ThrowsAsync<WorkloadException>(() => executor.ExecuteAsync(CancellationToken.None));
-                Assert.AreEqual(ErrorReason.PlatformNotSupported, exception.Reason);
-            }
-        }
-
-        [Test]
         public void RedisExecutorThrowsOnUnsupportedDistroAsync()
         {
             this.SetupDefaultMockBehavior(PlatformID.Unix);

--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/SysbenchOLTP/SysbenchOLTPExecutorTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/SysbenchOLTP/SysbenchOLTPExecutorTests.cs
@@ -48,19 +48,6 @@ namespace VirtualClient.Actions
         }
 
         [Test]
-        public void SysbenchOLTPExecutorThrowsOnUnsupportedPlatformAsync()
-        {
-            this.SetupDefaultMockBehavior(PlatformID.Win32NT);
-
-            using (TestSysbenchOLTPExecutor SysbenchOLTPExecutor = new TestSysbenchOLTPExecutor(this.fixture.Dependencies, this.fixture.Parameters))
-            {
-                WorkloadException exception = Assert.ThrowsAsync<WorkloadException>(
-                    () => SysbenchOLTPExecutor.ExecuteAsync(CancellationToken.None));
-                Assert.AreEqual(ErrorReason.PlatformNotSupported, exception.Reason);
-            }
-        }
-
-        [Test]
         public void SysbenchOLTPExecutorThrowsOnUnsupportedDistroAsync()
         {
             this.SetupDefaultMockBehavior(PlatformID.Unix);

--- a/src/VirtualClient/VirtualClient.Actions/3DMark/ThreeDMarkExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/3DMark/ThreeDMarkExecutor.cs
@@ -6,6 +6,7 @@ namespace VirtualClient.Actions
     using System;
     using System.Collections.Generic;
     using System.IO.Abstractions;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
@@ -126,6 +127,24 @@ namespace VirtualClient.Actions
 
             this.ExecutablePath = this.PlatformSpecifics.Combine(this.Package.Path, "3DMark", "3DMarkCmd.exe");
             this.DLCPath = this.PlatformSpecifics.Combine(this.Package.Path, "DLC", "3DMark");
+        }
+
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && this.Platform == PlatformID.Win32NT
+                && this.CpuArchitecture == Architecture.X64;
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("ThreeDMark", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
         }
 
         /// <summary>

--- a/src/VirtualClient/VirtualClient.Actions/7zip/Compression7zipExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/7zip/Compression7zipExecutor.cs
@@ -6,9 +6,11 @@ namespace VirtualClient.Actions
     using System;
     using System.Collections.Generic;
     using System.IO.Abstractions;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using VirtualClient.Common;
     using VirtualClient.Common.Extensions;
     using VirtualClient.Common.Platform;
@@ -128,12 +130,19 @@ namespace VirtualClient.Actions
         }
 
         /// <summary>
-        /// Returns true/false whether the component should execute on the system/platform.
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
         /// </summary>
-        /// <returns>Returns True or false</returns>
         protected override bool IsSupported()
         {
-            bool isSupported = this.Platform == PlatformID.Win32NT;
+            bool isSupported = base.IsSupported()
+                && this.Platform == PlatformID.Win32NT
+                && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("Compressor7zip", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
 
             return isSupported;
         }

--- a/src/VirtualClient/VirtualClient.Actions/ASPNET/AspNetBenchExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/ASPNET/AspNetBenchExecutor.cs
@@ -6,10 +6,12 @@ namespace VirtualClient.Actions
     using System;
     using System.Collections.Generic;
     using System.IO.Abstractions;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using VirtualClient.Common;
     using VirtualClient.Common.Extensions;
     using VirtualClient.Common.Telemetry;
@@ -93,6 +95,24 @@ namespace VirtualClient.Actions
             {
                 return this.Parameters.GetValue<string>(nameof(AspNetBenchExecutor.DotNetSdkPackageName), "dotnetsdk");
             }
+        }
+
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Win32NT || this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("AspNetBench", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
         }
 
         /// <summary>

--- a/src/VirtualClient/VirtualClient.Actions/CoreMark/CoreMarkExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/CoreMark/CoreMarkExecutor.cs
@@ -6,10 +6,12 @@ namespace VirtualClient.Actions
     using System;
     using System.Collections.Generic;
     using System.Globalization;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using VirtualClient.Common;
     using VirtualClient.Common.Extensions;
     using VirtualClient.Common.Platform;
@@ -142,6 +144,24 @@ namespace VirtualClient.Actions
             this.OutputFile2Path = this.Combine(this.PackagePath, CoreMarkExecutor.CoreMarkOutputFile2);
 
             return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Win32NT || this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("CoreMark", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
         }
 
         private string GetCommandLineArguments()

--- a/src/VirtualClient/VirtualClient.Actions/DiskSpd/DiskSpdExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/DiskSpd/DiskSpdExecutor.cs
@@ -6,9 +6,11 @@ namespace VirtualClient.Actions
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using VirtualClient.Common;
     using VirtualClient.Common.Extensions;
     using VirtualClient.Common.Platform;
@@ -290,6 +292,24 @@ namespace VirtualClient.Actions
             IProcessProxy process = this.SystemManagement.ProcessManager.CreateProcess(executable, diskSpdArguments);
 
             return new DiskWorkloadProcess(process, testedInstance, testFiles);
+        }
+
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Win32NT)
+                && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("DiskSpd", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
         }
 
         /// <summary>

--- a/src/VirtualClient/VirtualClient.Actions/FIO/FioExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/FIO/FioExecutor.cs
@@ -7,9 +7,11 @@ namespace VirtualClient.Actions
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using Polly;
     using VirtualClient.Common;
     using VirtualClient.Common.Extensions;
@@ -533,6 +535,25 @@ namespace VirtualClient.Actions
                commandArguments,
                this.Tags,
                telemetryContext);
+        }
+
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && 
+                ((this.Platform == PlatformID.Win32NT && this.CpuArchitecture == Architecture.X64) || 
+                (this.Platform == PlatformID.Unix && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64)));
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("Fio", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
         }
 
         private string SanitizeFilePath(string filePath)

--- a/src/VirtualClient/VirtualClient.Actions/Furmark/FurmarkExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Furmark/FurmarkExecutor.cs
@@ -12,6 +12,7 @@ namespace VirtualClient.Actions
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using VirtualClient.Common;
     using VirtualClient.Common.Extensions;
     using VirtualClient.Common.Platform;
@@ -157,9 +158,16 @@ namespace VirtualClient.Actions
         /// </summary>
         protected override bool IsSupported()
         {
-            return base.IsSupported() 
-                && this.Platform == PlatformID.Win32NT 
-                && this.CpuArchitecture == Architecture.X64;
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Win32NT)
+                && (this.CpuArchitecture == Architecture.X64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("Furmark", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
         }
 
         /// <summary>

--- a/src/VirtualClient/VirtualClient.Actions/Graph500/Graph500Executor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Graph500/Graph500Executor.cs
@@ -10,6 +10,7 @@ namespace VirtualClient.Actions
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using VirtualClient.Common;
     using VirtualClient.Common.Extensions;
     using VirtualClient.Common.Platform;
@@ -79,8 +80,6 @@ namespace VirtualClient.Actions
         /// </summary>
         protected override async Task InitializeAsync(EventContext telemetryContext, CancellationToken cancellationToken)
         {
-            this.ThrowIfPlatformIsNotSupported();
-
             IPackageManager packageManager = this.Dependencies.GetService<IPackageManager>();
             DependencyPath workloadPackage = await packageManager.GetPlatformSpecificPackageAsync(this.PackageName, this.Platform, this.CpuArchitecture, cancellationToken)
                 .ConfigureAwait(false);
@@ -111,15 +110,22 @@ namespace VirtualClient.Actions
             }
         }
 
-        private void ThrowIfPlatformIsNotSupported()
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
         {
-            if (this.Platform != PlatformID.Unix)
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64);
+
+            if (!isSupported)
             {
-                throw new WorkloadException(
-                    $"The Graph500 workload is currently only supported on the following platform/architectures: " +
-                    $"'{PlatformSpecifics.GetPlatformArchitectureName(PlatformID.Unix, Architecture.X64)}', '{PlatformSpecifics.GetPlatformArchitectureName(PlatformID.Unix, Architecture.Arm64)}'. ",
-                    ErrorReason.PlatformNotSupported);
+                this.Logger.LogNotSupported("Graph500", this.Platform, this.CpuArchitecture, EventContext.Persisted());
             }
+
+            return isSupported;
         }
 
         private async Task ExecuteCommandAsync(string pathToExe, string commandLineArguments, string workingDirectory, CancellationToken cancellationToken)

--- a/src/VirtualClient/VirtualClient.Actions/HPLinpack/HPLinpackExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/HPLinpack/HPLinpackExecutor.cs
@@ -10,6 +10,7 @@ namespace VirtualClient.Actions
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using VirtualClient.Common;
     using VirtualClient.Common.Extensions;
     using VirtualClient.Common.Platform;
@@ -242,6 +243,24 @@ namespace VirtualClient.Actions
             }
         }
 
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("HPLinPack", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
+        }
+
         private void SetParameters()
         {
             // gives you P*Q = Number of processes( Default: Environment.ProcessorCount, overwrite to value from command line to VC if supplied) and P <= Q and  Q-P to be the minimum possible value.
@@ -263,14 +282,7 @@ namespace VirtualClient.Actions
 
         private void ThrowIfPlatformIsNotSupported()
         {
-            if (this.Platform != PlatformID.Unix)
-            {
-                throw new WorkloadException(
-                    $"The HPL workload is currently only supported on the following platform/architectures: " +
-                    $"'{PlatformSpecifics.LinuxX64}', '{PlatformSpecifics.LinuxArm64}'.",
-                    ErrorReason.PlatformNotSupported);
-            }
-            else if (this.Platform == PlatformID.Unix && this.CpuArchitecture != Architecture.Arm64 && this.UsePerformanceLibraries == true)
+            if (this.Platform == PlatformID.Unix && this.CpuArchitecture != Architecture.Arm64 && this.UsePerformanceLibraries == true)
             {
                 throw new WorkloadException(
                     $"The HPL workload with performance Libraries is currently only supported on the following platform/architectures: " +

--- a/src/VirtualClient/VirtualClient.Actions/LAPACK/LAPACKExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/LAPACK/LAPACKExecutor.cs
@@ -6,10 +6,12 @@ namespace VirtualClient.Actions
     using System;
     using System.Collections.Generic;
     using System.IO.Abstractions;
+    using System.Runtime.InteropServices;
     using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using VirtualClient.Common;
     using VirtualClient.Common.Contracts;
     using VirtualClient.Common.Extensions;
@@ -59,11 +61,6 @@ namespace VirtualClient.Actions
         /// </summary>
         protected override async Task InitializeAsync(EventContext telemetryContext, CancellationToken cancellationToken)
         {
-            if (this.Platform != PlatformID.Win32NT && this.Platform != PlatformID.Unix)
-            {
-                throw new NotSupportedException($"'{this.Platform}' is not currently supported");
-            }
-
             IPackageManager packageManager = this.Dependencies.GetService<IPackageManager>();
             DependencyPath workloadPackage = await packageManager.GetPlatformSpecificPackageAsync(this.PackageName, this.Platform, this.CpuArchitecture, cancellationToken)
                 .ConfigureAwait(false);
@@ -144,6 +141,24 @@ namespace VirtualClient.Actions
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Win32NT || this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("LAPACK", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
         }
 
         private async Task ExecuteCommandAsync(string pathToExe, string commandLineArguments, string workingDirectory, CancellationToken cancellationToken)

--- a/src/VirtualClient/VirtualClient.Actions/LMbench/LMbenchExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/LMbench/LMbenchExecutor.cs
@@ -8,6 +8,7 @@ namespace VirtualClient.Actions
     using System.IO;
     using System.IO.Abstractions;
     using System.Linq;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
@@ -117,6 +118,24 @@ namespace VirtualClient.Actions
 
             this.LMbenchDirectory = workloadPackage.Path;
             this.resultsDirectory = this.PlatformSpecifics.Combine(this.LMbenchDirectory, "results");
+        }
+
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("LMbench", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
         }
 
         private void CaptureMetrics(IProcessProxy process, EventContext telemetryContext, CancellationToken cancellationToken)

--- a/src/VirtualClient/VirtualClient.Actions/Lzbench/LzbenchExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Lzbench/LzbenchExecutor.cs
@@ -7,9 +7,11 @@ namespace VirtualClient.Actions
     using System.Collections.Generic;
     using System.IO;
     using System.IO.Abstractions;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using VirtualClient.Common;
     using VirtualClient.Common.Extensions;
     using VirtualClient.Common.Platform;
@@ -158,12 +160,19 @@ namespace VirtualClient.Actions
         }
 
         /// <summary>
-        /// Returns true/false whether the component should execute on the system/platform.
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
         /// </summary>
-        /// <returns>Returns True or false</returns>
         protected override bool IsSupported()
         {
-            bool isSupported = this.Platform == PlatformID.Unix;
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("Lzbench", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
 
             return isSupported;
         }

--- a/src/VirtualClient/VirtualClient.Actions/MLPerf/MLPerfExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/MLPerf/MLPerfExecutor.cs
@@ -12,6 +12,7 @@ namespace VirtualClient.Actions
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using VirtualClient.Common;
     using VirtualClient.Common.Extensions;
     using VirtualClient.Common.Platform;
@@ -215,8 +216,6 @@ namespace VirtualClient.Actions
         {
             this.Logger.LogTraceMessage($"{this.TypeName}.InitializationStarted", telemetryContext);
 
-            this.ThrowIfPlatformNotSupported();
-
             await this.ThrowIfUnixDistroNotSupportedAsync(cancellationToken)
                 .ConfigureAwait(false);
 
@@ -393,6 +392,24 @@ namespace VirtualClient.Actions
 
         }
 
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("MLPerf", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
+        }
+
         private async Task CaptureMetricsAsync(IProcessProxy process, EventContext telemetryContext, CancellationToken cancellationToken, string context = null)
         {
             this.MetadataContract.AddForScenario(
@@ -489,23 +506,6 @@ namespace VirtualClient.Actions
                         true);
                     }
                 }
-            }
-        }
-
-        private void ThrowIfPlatformNotSupported()
-        {
-            switch (this.Platform)
-            {
-                case PlatformID.Unix:
-                    break;
-                default:
-                    throw new WorkloadException(
-                        $"The MLPerf benchmark workload is not supported on the current platform/architecture " +
-                        $"{PlatformSpecifics.GetPlatformArchitectureName(this.Platform, this.CpuArchitecture)}." +
-                        $" Supported platform/architectures include: " +
-                        $"{PlatformSpecifics.GetPlatformArchitectureName(PlatformID.Unix, Architecture.X64)}, " +
-                        $"{PlatformSpecifics.GetPlatformArchitectureName(PlatformID.Unix, Architecture.Arm64)}",
-                        ErrorReason.PlatformNotSupported);
             }
         }
 

--- a/src/VirtualClient/VirtualClient.Actions/Memcached/MemcachedExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Memcached/MemcachedExecutor.cs
@@ -12,6 +12,7 @@ namespace VirtualClient.Actions
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
     using VirtualClient.Actions.NetworkPerformance;
     using VirtualClient.Common;
@@ -204,6 +205,24 @@ namespace VirtualClient.Actions
                 this.ServerApiClient = clientManager.GetOrCreateApiClient(serverIPAddress.ToString(), serverIPAddress);
                 this.RegisterToSendExitNotifications($"{this.TypeName}.ExitNotification", this.ServerApiClient);
             }
+        }
+
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("Memcached", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
         }
 
         private async Task ValidatePlatformSupportAsync(CancellationToken cancellationToken)

--- a/src/VirtualClient/VirtualClient.Actions/Memtier/MemtierBenchmarkClientExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Memtier/MemtierBenchmarkClientExecutor.cs
@@ -7,6 +7,7 @@ namespace VirtualClient.Actions
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Net;
+    using System.Runtime.InteropServices;
     using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
@@ -284,6 +285,24 @@ namespace VirtualClient.Actions
                     $"See the documentation on Memtier for supported protocols.",
                     ErrorReason.InvalidProfileDefinition);
             }
+        }
+
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("MemtierBenchmark", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
         }
 
         private void CaptureMetrics(string results, string commandArguments, DateTime startTime, DateTime endTime, EventContext telemetryContext, CancellationToken cancellationToken)

--- a/src/VirtualClient/VirtualClient.Actions/Network/NetworkPingExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Network/NetworkPingExecutor.cs
@@ -10,6 +10,7 @@ namespace VirtualClient.Actions.NetworkPerformance
     using System.Linq;
     using System.Net;
     using System.Net.NetworkInformation;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
@@ -100,6 +101,24 @@ namespace VirtualClient.Actions.NetworkPerformance
             }
 
             return this.ExecutePingServerAsync(ipAddress, telemetryContext, cancellationToken);
+        }
+
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Win32NT || this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("NetworkPing", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
         }
 
         private async Task ExecutePingServerAsync(IPAddress ipAddress, EventContext telemetryContext, CancellationToken cancellationToken)

--- a/src/VirtualClient/VirtualClient.Actions/OpenSSL/OpenSslExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/OpenSSL/OpenSslExecutor.cs
@@ -7,6 +7,7 @@ namespace VirtualClient.Actions
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO.Abstractions;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
@@ -90,6 +91,25 @@ namespace VirtualClient.Actions
 
             await this.InitializeWorkloadToolsetsAsync(cancellationToken)
                 .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && 
+                ((this.Platform == PlatformID.Win32NT && this.CpuArchitecture == Architecture.X64)
+                || (this.Platform == PlatformID.Unix && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64)));
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("OpenSsl", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
         }
 
         private void CaptureMetrics(IProcessProxy workloadProcess, string commandArguments, EventContext telemetryContext)

--- a/src/VirtualClient/VirtualClient.Actions/Pbzip2/Pbzip2Executor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Pbzip2/Pbzip2Executor.cs
@@ -6,9 +6,11 @@ namespace VirtualClient.Actions
     using System;
     using System.Collections.Generic;
     using System.IO.Abstractions;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using VirtualClient.Common;
     using VirtualClient.Common.Extensions;
     using VirtualClient.Common.Platform;
@@ -131,12 +133,19 @@ namespace VirtualClient.Actions
         }
 
         /// <summary>
-        /// Returns true/false whether the component should execute on the system/platform.
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
         /// </summary>
-        /// <returns>Returns True or false</returns>
         protected override bool IsSupported()
         {
-            bool isSupported = this.Platform == PlatformID.Unix;
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("Pbzip2", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
 
             return isSupported;
         }

--- a/src/VirtualClient/VirtualClient.Actions/PostgreSQL/PostgreSQLExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/PostgreSQL/PostgreSQLExecutor.cs
@@ -12,6 +12,7 @@ namespace VirtualClient.Actions
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
     using VirtualClient;
     using VirtualClient.Common;
@@ -245,6 +246,24 @@ namespace VirtualClient.Actions
                     this.Tags,
                     telemetryContext);
             }
+        }
+
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Win32NT || this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("PostgreSQL", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
         }
 
         /// <summary>

--- a/src/VirtualClient/VirtualClient.Actions/Prime95/Prime95Executor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Prime95/Prime95Executor.cs
@@ -8,6 +8,7 @@ namespace VirtualClient.Actions
     using System.IO;
     using System.IO.Abstractions;
     using System.Linq;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Http;
@@ -237,11 +238,13 @@ namespace VirtualClient.Actions
 
         /// <summary>
         /// Returns true/false whether the component is supported on the current
-        /// operating system and CPU architecture.
+        /// OS platform and CPU architecture.
         /// </summary>
         protected override bool IsSupported()
         {
-            bool isSupported = base.IsSupported() && (this.Platform == PlatformID.Win32NT || this.Platform == PlatformID.Unix);
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Win32NT || this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64);
 
             if (!isSupported)
             {

--- a/src/VirtualClient/VirtualClient.Actions/Redis/RedisExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Redis/RedisExecutor.cs
@@ -126,6 +126,7 @@ namespace VirtualClient.Actions
         /// </summary>
         protected override async Task InitializeAsync(EventContext telemetryContext, CancellationToken cancellationToken)
         {
+            await this.ValidatePlatformSupportAsync(cancellationToken);
             await this.EvaluateParametersAsync(cancellationToken);
 
             if (this.IsMultiRoleLayout())
@@ -176,7 +177,49 @@ namespace VirtualClient.Actions
                 this.ServerApiClient = clientManager.GetOrCreateApiClient(serverIPAddress.ToString(), serverIPAddress);
                 this.RegisterToSendExitNotifications($"{this.TypeName}.ExitNotification", this.ServerApiClient);
             }
-        }        
+        }
+
+        private async Task ValidatePlatformSupportAsync(CancellationToken cancellationToken)
+        {
+            switch (this.Platform)
+            {
+                case PlatformID.Unix:
+                    if (this.Platform == PlatformID.Unix)
+                    {
+                        LinuxDistributionInfo distroInfo = await this.SystemManagement.GetLinuxDistributionAsync(cancellationToken);
+
+                        if (!cancellationToken.IsCancellationRequested)
+                        {
+                            switch (distroInfo.LinuxDistribution)
+                            {
+                                case LinuxDistribution.Ubuntu:
+                                case LinuxDistribution.Debian:
+                                case LinuxDistribution.CentOS8:
+                                case LinuxDistribution.RHEL8:
+                                    break;
+                                default:
+                                    throw new WorkloadException(
+                                        $"The Redis Memtier benchmark workload is not supported on the current Linux distro " +
+                                        $"'{distroInfo.LinuxDistribution}'.  Supported distros include: " +
+                                        $"{Enum.GetName(typeof(LinuxDistribution), LinuxDistribution.Ubuntu)},{Enum.GetName(typeof(LinuxDistribution), LinuxDistribution.Debian)}" +
+                                        $"{Enum.GetName(typeof(LinuxDistribution), LinuxDistribution.CentOS8)},{Enum.GetName(typeof(LinuxDistribution), LinuxDistribution.RHEL8)}",
+                                        ErrorReason.LinuxDistributionNotSupported);
+                            }
+                        }
+                    }
+
+                    break;
+
+                default:
+                    throw new WorkloadException(
+                        $"The Redis Memtier benchmark workload is currently not supported on the current platform/architecture " +
+                        $"'{this.PlatformArchitectureName}'." +
+                        $" Supported platform/architectures include: " +
+                        $"{PlatformSpecifics.GetPlatformArchitectureName(PlatformID.Unix, Architecture.X64)}, " +
+                        $"{PlatformSpecifics.GetPlatformArchitectureName(PlatformID.Unix, Architecture.Arm64)}",
+                        ErrorReason.PlatformNotSupported);
+            }
+        }
 
         internal class ServerState : State
         {

--- a/src/VirtualClient/VirtualClient.Actions/SPECcpu/SpecCpuExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/SPECcpu/SpecCpuExecutor.cs
@@ -176,6 +176,24 @@ namespace VirtualClient.Actions
             await this.SetupSpecCpuAsync(imageFile, telemetryContext, cancellationToken);
         }
 
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Win32NT || this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("SpecCpu", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
+        }
+
         private string GetConfigurationFileName()
         {
             switch ((this.Platform, this.CpuArchitecture))

--- a/src/VirtualClient/VirtualClient.Actions/SPECjbb/SpecJbbExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/SPECjbb/SpecJbbExecutor.cs
@@ -8,6 +8,7 @@ namespace VirtualClient.Actions
     using System.IO;
     using System.IO.Abstractions;
     using System.Linq;
+    using System.Runtime.InteropServices;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
@@ -145,6 +146,24 @@ namespace VirtualClient.Actions
 
             this.javaExecutableDirectory = javaExecutable.Metadata[PackageMetadata.ExecutablePath].ToString();
             this.gcLogPath = this.PlatformSpecifics.Combine(this.packageDirectory, SpecJbbExecutor.GcLogName);
+        }
+
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Win32NT || this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("SpecJbb", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
         }
 
         private async Task CaptureMetricsAsync(IProcessProxy process, string commandArguments, EventContext telemetryContext, CancellationToken cancellationToken)

--- a/src/VirtualClient/VirtualClient.Actions/SPECjvm/SpecJvmExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/SPECjvm/SpecJvmExecutor.cs
@@ -7,6 +7,7 @@ namespace VirtualClient.Actions
     using System.Collections.Generic;
     using System.IO;
     using System.IO.Abstractions;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
@@ -113,6 +114,24 @@ namespace VirtualClient.Actions
             }
 
             this.javaExecutableDirectory = javaExecutable.Metadata[PackageMetadata.ExecutablePath].ToString();
+        }
+
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Win32NT || this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("SpecJvm", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
         }
 
         private async Task ExecuteWorkloadAsync(string pathToExe, string commandLineArguments, string workingDirectory, CancellationToken cancellationToken)

--- a/src/VirtualClient/VirtualClient.Actions/SPECpower/SPECPowerExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/SPECpower/SPECPowerExecutor.cs
@@ -8,6 +8,7 @@ namespace VirtualClient.Actions
     using System.Collections.Immutable;
     using System.Diagnostics;
     using System.Linq;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using global::VirtualClient;
@@ -180,6 +181,24 @@ namespace VirtualClient.Actions
             }
 
             SPECPowerExecutor.JavaExecutablePath = javaExecutable.Metadata[PackageMetadata.ExecutablePath].ToString();
+        }
+
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Win32NT || this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("SPECPower", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
         }
 
         /// <summary>

--- a/src/VirtualClient/VirtualClient.Actions/StressAppTest/StressAppTestExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/StressAppTest/StressAppTestExecutor.cs
@@ -6,6 +6,7 @@ namespace VirtualClient.Actions
     using System;
     using System.Collections.Generic;
     using System.IO.Abstractions;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
@@ -154,6 +155,24 @@ namespace VirtualClient.Actions
                     $"-l parameter. That is being appended programatically",
                     ErrorReason.InvalidProfileDefinition);
             }
+        }
+
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("StressAppTest", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
         }
 
         /// <summary>

--- a/src/VirtualClient/VirtualClient.Actions/StressNg/StressNgExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/StressNg/StressNgExecutor.cs
@@ -6,6 +6,7 @@ namespace VirtualClient.Actions
     using System;
     using System.Collections.Generic;
     using System.IO.Abstractions;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
@@ -97,6 +98,24 @@ namespace VirtualClient.Actions
             this.stressNgOutputFilePath = this.PlatformSpecifics.Combine(this.stressNgDirectory, "vcStressNg.yaml");
 
             return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Win32NT || this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64 || this.CpuArchitecture == Architecture.Arm64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("StressNg", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
         }
 
         private async Task CaptureMetricsAsync(IProcessProxy process, string commandArguments, EventContext telemetryContext, CancellationToken cancellationToken)

--- a/src/VirtualClient/VirtualClient.Actions/SuperBenchmark/SuperBenchmarkExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/SuperBenchmark/SuperBenchmarkExecutor.cs
@@ -7,6 +7,7 @@ namespace VirtualClient.Actions
     using System.Collections.Generic;
     using System.IO;
     using System.IO.Abstractions;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
@@ -179,6 +180,24 @@ namespace VirtualClient.Actions
             }
 
             await this.stateManager.SaveStateAsync<SuperBenchmarkState>($"{nameof(SuperBenchmarkState)}", state, cancellationToken);
+        }
+
+        /// <summary>
+        /// Returns true/false whether the component is supported on the current
+        /// OS platform and CPU architecture.
+        /// </summary>
+        protected override bool IsSupported()
+        {
+            bool isSupported = base.IsSupported()
+                && (this.Platform == PlatformID.Unix)
+                && (this.CpuArchitecture == Architecture.X64);
+
+            if (!isSupported)
+            {
+                this.Logger.LogNotSupported("SuperBenchmark", this.Platform, this.CpuArchitecture, EventContext.Persisted());
+            }
+
+            return isSupported;
         }
 
         private async Task ExecuteSbCommandAsync(string command, string commandArguments, string workingDirectory, EventContext telemetryContext, CancellationToken cancellationToken, bool runElevated)


### PR DESCRIPTION
In Virtual Client, we used to throw error if workload is not supported for current platform and architecture but if we have multiple workloads in single profile and workloads are meant to run for different permutations and combinations of platform and architecture support, it makes sense that we go on with profile and not throw error if one of the intermediate workload is not supported.