### PR TITLE
Forcing blob name, blob path and dependency to be strictly small case

### DIFF
--- a/src/VirtualClient/VirtualClient.Contracts/DependencyDescriptor.cs
+++ b/src/VirtualClient/VirtualClient.Contracts/DependencyDescriptor.cs
@@ -65,7 +65,7 @@ namespace VirtualClient.Contracts
 
             set
             {
-                this[nameof(this.Name)] = value;
+                this[nameof(this.Name)] = value?.ToLowerInvariant();
             }
         }
 

--- a/src/VirtualClient/VirtualClient.Core.UnitTests/BlobManagerTests.cs
+++ b/src/VirtualClient/VirtualClient.Core.UnitTests/BlobManagerTests.cs
@@ -91,7 +91,7 @@ namespace VirtualClient
             {
                 invalidBlobNames.ForEach(name =>
                 {
-                    this.mockDescriptor.Name = name;
+                    this.mockDescriptor.Name = name ?.ToLowerInvariant();
 
                     Assert.ThrowsAsync<ArgumentException>(
                         () => this.blobManager.DownloadBlobAsync(this.mockDescriptor, downloadStream, CancellationToken.None, Policy.NoOpAsync()));
@@ -99,7 +99,7 @@ namespace VirtualClient
 
                 validBlobNames.ForEach(name =>
                 {
-                    this.mockDescriptor.Name = name;
+                    this.mockDescriptor.Name = name.ToLowerInvariant();
 
                     Assert.DoesNotThrowAsync(
                         () => this.blobManager.DownloadBlobAsync(this.mockDescriptor, downloadStream, CancellationToken.None, Policy.NoOpAsync()));
@@ -288,7 +288,7 @@ namespace VirtualClient
             {
                 invalidBlobNames.ForEach(name =>
                 {
-                    this.mockDescriptor.Name = name;
+                    this.mockDescriptor.Name = name ?.ToLowerInvariant();
 
                     Assert.ThrowsAsync<ArgumentException>(
                         () => this.blobManager.UploadBlobAsync(this.mockDescriptor, uploadStream, CancellationToken.None, Policy.NoOpAsync()));
@@ -296,7 +296,7 @@ namespace VirtualClient
 
                 validBlobNames.ForEach(name =>
                 {
-                    this.mockDescriptor.Name = name;
+                    this.mockDescriptor.Name = name.ToLowerInvariant();
 
                     Assert.DoesNotThrowAsync(
                         () => this.blobManager.UploadBlobAsync(this.mockDescriptor, uploadStream, CancellationToken.None, Policy.NoOpAsync()));

--- a/src/VirtualClient/VirtualClient.Core.UnitTests/PackageManagerTests.cs
+++ b/src/VirtualClient/VirtualClient.Core.UnitTests/PackageManagerTests.cs
@@ -420,6 +420,7 @@ namespace VirtualClient
         {
             this.SetupDependencyPackageInstallationDefaultMockBehaviors();
 
+            name = name?.ToLowerInvariant();
             this.mockDependencyDescription.Name = name;
             this.mockDependencyDescription.ArchiveType = ArchiveType.Zip;
             string expectedArchivePath = this.mockFixture.GetPackagePath(name);
@@ -459,6 +460,7 @@ namespace VirtualClient
             this.SetupMocks(PlatformID.Unix);
             this.SetupDependencyPackageInstallationDefaultMockBehaviors();
 
+            name = name?.ToLowerInvariant();
             this.mockDependencyDescription.Name = name;
             this.mockDependencyDescription.ArchiveType = ArchiveType.Tgz;
             string expectedArchivePath = this.mockFixture.GetPackagePath(name);


### PR DESCRIPTION
Enforcing the blob name, blob path and dependency to be strictly small case as has been already being followed in the code base.

All VC test cases are passing and have been run successfully.
Failing testcases during unit testing have been corrected.