### PR TITLE
Add logging to the SafeKill method for SockPerf and Latte server-side executors to help determine if there is an error preventing the process from being effectively killed.

### DIFF
--- a/.pipelines/azure-pipelines-linux.yml
+++ b/.pipelines/azure-pipelines-linux.yml
@@ -16,7 +16,7 @@ resources:
     options: --entrypoint=""
 
 variables:
-  VcVersion : 1.11.7
+  VcVersion : 1.11.8
   ROOT: $(Build.SourcesDirectory)
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   ENABLE_PRS_DELAYSIGN: 1

--- a/.pipelines/azure-pipelines.yml
+++ b/.pipelines/azure-pipelines.yml
@@ -18,7 +18,7 @@ pool:
   vmImage: windows-latest
 
 variables:
-  VcVersion : 1.11.7
+  VcVersion : 1.11.8
   ROOT: $(Build.SourcesDirectory)
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   ENABLE_PRS_DELAYSIGN: 1

--- a/src/VirtualClient/VirtualClient.Actions/Network/NetworkingWorkload/Latte/LatteServerExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Network/NetworkingWorkload/Latte/LatteServerExecutor.cs
@@ -68,7 +68,7 @@ namespace VirtualClient.Actions.NetworkPerformance
                                     }
                                     finally
                                     {
-                                        process.SafeKill();
+                                        process.SafeKill(this.Logger);
                                     }
                                 }
                             }

--- a/src/VirtualClient/VirtualClient.Actions/Network/NetworkingWorkload/SockPerf/SockPerfServerExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Network/NetworkingWorkload/SockPerf/SockPerfServerExecutor.cs
@@ -77,7 +77,7 @@ namespace VirtualClient.Actions.NetworkPerformance
                                     {
                                         // SockPerf must be explicitly terminated given the current implementation. If it is not,
                                         // the process will remain running in the background.
-                                        process.SafeKill();
+                                        process.SafeKill(this.Logger);
                                     }
                                 }
                             }

--- a/src/VirtualClient/VirtualClient.Actions/Network2/NetworkingWorkload2/Latte/LatteServerExecutor2.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Network2/NetworkingWorkload2/Latte/LatteServerExecutor2.cs
@@ -376,7 +376,7 @@ namespace VirtualClient.Actions
                                         }
                                         finally
                                         {
-                                            process.SafeKill();
+                                            process.SafeKill(this.Logger);
                                         }
                                     }
                                 }

--- a/src/VirtualClient/VirtualClient.Actions/Network2/NetworkingWorkload2/SockPerf/SockPerfServerExecutor2.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Network2/NetworkingWorkload2/SockPerf/SockPerfServerExecutor2.cs
@@ -379,7 +379,7 @@ namespace VirtualClient.Actions
                                     {
                                         // SockPerf must be explicitly terminated given the current implementation. If it is not,
                                         // the process will remain running in the background.
-                                        process.SafeKill();
+                                        process.SafeKill(this.Logger);
                                     }
                                 }
                             }


### PR DESCRIPTION
- add logging to SockPerf server-side executor SafeKill method call.
- add logging to Latte server-side executor SafeKill method call.