### PR TITLE
Add global.json to specify SDK version and ensure consistent builds

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "7.0.403",
+    "rollForward": "disable"
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.403",
+    "version": "6.0.416",
     "rollForward": "disable"
   }
 }


### PR DESCRIPTION
To maintain consistency across all development and build environments, a global.json file is added to the repository. This file specifies the exact .NET SDK version to be used, which helps to avoid discrepancies that can arise from developers using different versions of the SDK. This ensures that all builds, whether on local machines or build servers, use the same version of the SDK, reducing the "it works on my machine" or "it doesn't work on my machine" syndrome. It also aids in smoother transitions between SDK versions by providing explicit control over the upgrade process in a coordinated manner across all environments.

Fixes #212 