### PR TITLE
Sockperf reset instruction from client

### DIFF
--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/Network2/SockPerf/SockPerfClientExecutorTests2.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/Network2/SockPerf/SockPerfClientExecutorTests2.cs
@@ -52,7 +52,6 @@ namespace VirtualClient.Actions
                     Item<Instructions> stateItem = obj.ToObject<Item<Instructions>>();
                     if (stateItem.Definition.Type == InstructionsType.ClientServerReset)
                     {
-                        Assert.AreEqual(sendInstructionsExecuted, 0);
                         sendInstructionsExecuted++;
                     }
 
@@ -73,7 +72,7 @@ namespace VirtualClient.Actions
             TestSockPerfClientExecutor component = new TestSockPerfClientExecutor(this.mockFixture.Dependencies, this.mockFixture.Parameters);
 
             await component.ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
-            Assert.AreEqual(sendInstructionsExecuted, 2);
+            Assert.AreEqual(sendInstructionsExecuted, 3);
         }
 
         [Test]
@@ -95,7 +94,6 @@ namespace VirtualClient.Actions
             TestSockPerfClientExecutor component = new TestSockPerfClientExecutor(this.mockFixture.Dependencies, this.mockFixture.Parameters);
 
             await component.ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
-
 
             string exe = "sockperf";
             Assert.AreEqual(2, processExecuted);
@@ -143,6 +141,7 @@ namespace VirtualClient.Actions
             this.mockFixture.ApiClient.SetupSequence(client => client.GetStateAsync(nameof(SockPerfWorkloadState), It.IsAny<CancellationToken>(), It.IsAny<IAsyncPolicy<HttpResponseMessage>>()))
                 .ReturnsAsync(this.mockFixture.CreateHttpResponse(System.Net.HttpStatusCode.NotFound))
                 .ReturnsAsync(this.mockFixture.CreateHttpResponse(System.Net.HttpStatusCode.OK, expectedStateItem))
+                .ReturnsAsync(this.mockFixture.CreateHttpResponse(System.Net.HttpStatusCode.NotFound))
                 .ReturnsAsync(this.mockFixture.CreateHttpResponse(System.Net.HttpStatusCode.NotFound));
         }
 

--- a/src/VirtualClient/VirtualClient.Actions/Network2/NetworkingWorkload2/SockPerf/SockPerfClientExecutor2.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Network2/NetworkingWorkload2/SockPerf/SockPerfClientExecutor2.cs
@@ -277,6 +277,9 @@ namespace VirtualClient.Actions
                 {
                     await this.DeleteResultsFileAsync().ConfigureAwait(false);
 
+                    await this.ResetServerAsync(telemetryContext, cancellationToken)
+                    .ConfigureAwait(false);
+
                     this.Logger.LogTraceMessage("Synchronization: Wait for server to stop workload...");
                     await this.ServerApiClient.PollForStateDeletedAsync(nameof(SockPerfWorkloadState), this.StateConfirmationPollingTimeout, cancellationToken);
                 }


### PR DESCRIPTION
SockPerf Server doesn't receive reset instruction from client at the end of client's execution and client keeps on waiting for the reset server (stopping server and state deletion). Adding the reset instruction from client to server. 