### PR TITLE
Superbenchmark executor: online inference config file and custom repo link

### DIFF
--- a/src/VirtualClient/VirtualClient.Actions/SuperBenchmark/SuperBenchmarkExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/SuperBenchmark/SuperBenchmarkExecutor.cs
@@ -28,6 +28,7 @@ namespace VirtualClient.Actions
         private const string SuperBenchmarkRunShell = "RunSuperBenchmark.sh";
         private const string DefaultSBRepoLink = "https://github.com/microsoft/superbenchmark";
         private string configFileFullPath;
+        private string repositoryName;
 
         private IFileSystem fileSystem;
         private IPackageManager packageManager;
@@ -119,7 +120,7 @@ namespace VirtualClient.Actions
         {
             get
             {
-                return this.PlatformSpecifics.Combine(this.PlatformSpecifics.PackagesDirectory, "superbenchmark");
+                return this.PlatformSpecifics.Combine(this.PlatformSpecifics.PackagesDirectory, this.repositoryName);
             }
         }
 
@@ -169,16 +170,19 @@ namespace VirtualClient.Actions
 
             if (!state.SuperBenchmarkInitialized)
             {
+                var repositoryLinkUri = new Uri(this.ConfigurationFile);
+                this.repositoryName = Path.GetFileName(repositoryLinkUri.AbsolutePath);
+
                 // This is to grant directory folders for 
                 await this.systemManager.MakeFilesExecutableAsync(this.PlatformSpecifics.CurrentDirectory, this.Platform, cancellationToken);
 
-                string cloneDir = this.PlatformSpecifics.Combine(this.PlatformSpecifics.PackagesDirectory, "superbenchmark");
+                string cloneDir = this.PlatformSpecifics.Combine(this.PlatformSpecifics.PackagesDirectory, "this.repositoryName");
                 if (!this.fileSystem.Directory.Exists(cloneDir))
                 {
                     await this.ExecuteSbCommandAsync("git", $"clone -b v{this.Version} {this.RepositoryLink}", this.PlatformSpecifics.PackagesDirectory, telemetryContext, cancellationToken, true);
                 }
 
-                foreach (string file in this.fileSystem.Directory.GetFiles(this.PlatformSpecifics.GetScriptPath("superbenchmark")))
+                foreach (string file in this.fileSystem.Directory.GetFiles(this.PlatformSpecifics.GetScriptPath("this.repositoryName")))
                 {
                     this.fileSystem.File.Copy(
                         file,
@@ -237,7 +241,7 @@ namespace VirtualClient.Actions
             if (!cancellationToken.IsCancellationRequested)
             {
                 this.MetadataContract.AddForScenario(
-                    "SuperBenchmark",
+                    this.repositoryName,
                     process.FullCommand(),
                     toolVersion: null);
 
@@ -254,8 +258,8 @@ namespace VirtualClient.Actions
                     IList<Metric> metrics = parser.Parse();
 
                     this.Logger.LogMetrics(
-                        toolName: "SuperBenchmark",
-                        scenarioName: "SuperBenchmark",
+                        toolName: this.repositoryName,
+                        scenarioName: this.repositoryName,
                         process.StartTime,
                         process.ExitTime,
                         metrics,

--- a/src/VirtualClient/VirtualClient.Actions/SuperBenchmark/SuperBenchmarkExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/SuperBenchmark/SuperBenchmarkExecutor.cs
@@ -170,19 +170,19 @@ namespace VirtualClient.Actions
 
             if (!state.SuperBenchmarkInitialized)
             {
-                var repositoryLinkUri = new Uri(this.ConfigurationFile);
+                var repositoryLinkUri = new Uri(this.RepositoryLink);
                 this.repositoryName = Path.GetFileName(repositoryLinkUri.AbsolutePath);
 
                 // This is to grant directory folders for 
                 await this.systemManager.MakeFilesExecutableAsync(this.PlatformSpecifics.CurrentDirectory, this.Platform, cancellationToken);
 
-                string cloneDir = this.PlatformSpecifics.Combine(this.PlatformSpecifics.PackagesDirectory, "this.repositoryName");
+                string cloneDir = this.PlatformSpecifics.Combine(this.PlatformSpecifics.PackagesDirectory, this.repositoryName);
                 if (!this.fileSystem.Directory.Exists(cloneDir))
                 {
                     await this.ExecuteSbCommandAsync("git", $"clone -b v{this.Version} {this.RepositoryLink}", this.PlatformSpecifics.PackagesDirectory, telemetryContext, cancellationToken, true);
                 }
 
-                foreach (string file in this.fileSystem.Directory.GetFiles(this.PlatformSpecifics.GetScriptPath("this.repositoryName")))
+                foreach (string file in this.fileSystem.Directory.GetFiles(this.PlatformSpecifics.GetScriptPath("superbenchmark")))
                 {
                     this.fileSystem.File.Copy(
                         file,

--- a/src/VirtualClient/VirtualClient.Actions/SuperBenchmark/SuperBenchmarkExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/SuperBenchmark/SuperBenchmarkExecutor.cs
@@ -165,6 +165,9 @@ namespace VirtualClient.Actions
         /// </summary>
         protected override async Task InitializeAsync(EventContext telemetryContext, CancellationToken cancellationToken)
         {
+            var repositoryLinkUri = new Uri(this.RepositoryLink);
+            this.repositoryName = Path.GetFileName(repositoryLinkUri.AbsolutePath);
+            
             // download config file if a link is provided
             if (this.ConfigurationFile.StartsWith("http"))
             {                
@@ -191,14 +194,11 @@ namespace VirtualClient.Actions
                 this.configFileFullPath = this.ConfigurationFile;
             }
 
-            SuperBenchmarkState state = await this.stateManager.GetStateAsync<SuperBenchmarkState>($"{nameof(SuperBenchmarkState)}", cancellationToken)
+            SuperBenchmarkState state = await this.stateManager.GetStateAsync<SuperBenchmarkState>(this.repositoryName, cancellationToken)
                 ?? new SuperBenchmarkState();
 
             if (!state.SuperBenchmarkInitialized)
             {
-                var repositoryLinkUri = new Uri(this.RepositoryLink);
-                this.repositoryName = Path.GetFileName(repositoryLinkUri.AbsolutePath);
-
                 // This is to grant directory folders for 
                 await this.systemManager.MakeFilesExecutableAsync(this.PlatformSpecifics.CurrentDirectory, this.Platform, cancellationToken);
 
@@ -222,7 +222,7 @@ namespace VirtualClient.Actions
                 state.SuperBenchmarkInitialized = true;
             }
 
-            await this.stateManager.SaveStateAsync<SuperBenchmarkState>($"{nameof(SuperBenchmarkState)}", state, cancellationToken);
+            await this.stateManager.SaveStateAsync<SuperBenchmarkState>(this.repositoryName, state, cancellationToken);
         }
 
         private async Task ExecuteSbCommandAsync(string command, string commandArguments, string workingDirectory, EventContext telemetryContext, CancellationToken cancellationToken, bool runElevated)

--- a/src/VirtualClient/VirtualClient.Actions/SuperBenchmark/SuperBenchmarkExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/SuperBenchmark/SuperBenchmarkExecutor.cs
@@ -26,6 +26,7 @@ namespace VirtualClient.Actions
     public class SuperBenchmarkExecutor : VirtualClientComponent
     {
         private const string SuperBenchmarkRunShell = "RunSuperBenchmark.sh";
+        private const string DefaultSBRepoLink = "https://github.com/microsoft/superbenchmark";
         private string configFileFullPath;
 
         private IFileSystem fileSystem;
@@ -80,6 +81,17 @@ namespace VirtualClient.Actions
             {
                 this.Parameters.TryGetValue(nameof(SuperBenchmarkExecutor.ConfigurationFile), out IConvertible config);
                 return config?.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Link to the superbench repo.
+        /// </summary>
+        public string RepositoryLink
+        {
+            get
+            {
+                return this.Parameters.GetValue<string>(nameof(SuperBenchmarkExecutor.RepositoryLink), DefaultSBRepoLink);
             }
         }
 
@@ -163,7 +175,7 @@ namespace VirtualClient.Actions
                 string cloneDir = this.PlatformSpecifics.Combine(this.PlatformSpecifics.PackagesDirectory, "superbenchmark");
                 if (!this.fileSystem.Directory.Exists(cloneDir))
                 {
-                    await this.ExecuteSbCommandAsync("git", $"clone -b v{this.Version} https://github.com/microsoft/superbenchmark", this.PlatformSpecifics.PackagesDirectory, telemetryContext, cancellationToken, true);
+                    await this.ExecuteSbCommandAsync("git", $"clone -b v{this.Version} {this.RepositoryLink}", this.PlatformSpecifics.PackagesDirectory, telemetryContext, cancellationToken, true);
                 }
 
                 foreach (string file in this.fileSystem.Directory.GetFiles(this.PlatformSpecifics.GetScriptPath("superbenchmark")))


### PR DESCRIPTION
Added support for
1. Feeding an online inference config file as a link, without the need to zip into packages and upload to storage account
2. Feeding a different superbenchmark repo link other the default microsoft SB repo. Some users have added more benchmark to their own version of superbench and can use this method run them in VC. 