### PR TITLE
Support Redis memtier benchmark on AzLinux

### DIFF
--- a/src/VirtualClient/VirtualClient.Actions/Redis/RedisExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Redis/RedisExecutor.cs
@@ -178,6 +178,7 @@ namespace VirtualClient.Actions
                                 case LinuxDistribution.Debian:
                                 case LinuxDistribution.CentOS8:
                                 case LinuxDistribution.RHEL8:
+                                case LinuxDistribution.AzLinux:
                                     break;
                                 default:
                                     throw new WorkloadException(


### PR DESCRIPTION
This PR adds a case statement to support the Redis memtier benchmark on AzLinux. This update enables proper detection and handling of the AzLinux distribution when running the Redis memtier benchmark.