### PR TITLE
CompilerInstallation fix: Remove existing alternatives for cpp

### DIFF
--- a/src/VirtualClient/VirtualClient.Dependencies.UnitTests/CompilerInstallationTests.cs
+++ b/src/VirtualClient/VirtualClient.Dependencies.UnitTests/CompilerInstallationTests.cs
@@ -110,7 +110,7 @@ namespace VirtualClient.Dependencies
                 await compilerInstallation.ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
             }
 
-            Assert.AreEqual(expectedCommands.Count(), commandExecuted);
+            Assert.AreEqual(9, commandExecuted);
         }
 
         [Test]
@@ -287,7 +287,7 @@ namespace VirtualClient.Dependencies
                 await compilerInstallation.ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
             }
 
-            Assert.AreEqual(expectedCommands.Count(), commandExecuted);
+            Assert.AreEqual(9, commandExecuted);
         }
 
         [Test]

--- a/src/VirtualClient/VirtualClient.Dependencies.UnitTests/CompilerInstallationTests.cs
+++ b/src/VirtualClient/VirtualClient.Dependencies.UnitTests/CompilerInstallationTests.cs
@@ -110,7 +110,7 @@ namespace VirtualClient.Dependencies
                 await compilerInstallation.ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
             }
 
-            Assert.AreEqual(9, commandExecuted);
+            Assert.AreEqual(expectedCommands.Count(), commandExecuted);
         }
 
         [Test]
@@ -287,7 +287,7 @@ namespace VirtualClient.Dependencies
                 await compilerInstallation.ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
             }
 
-            Assert.AreEqual(9, commandExecuted);
+            Assert.AreEqual(expectedCommands.Count(), commandExecuted);
         }
 
         [Test]

--- a/src/VirtualClient/VirtualClient.Dependencies/CompilerInstallation.cs
+++ b/src/VirtualClient/VirtualClient.Dependencies/CompilerInstallation.cs
@@ -276,6 +276,9 @@ namespace VirtualClient.Dependencies
 
             await this.ExecuteCommandAsync("update-alternatives", updateAlternativeArgument, Environment.CurrentDirectory, telemetryContext, cancellationToken);
 
+            // Remove all existing alternatives for cpp before the subsequent "update-alternatives" of cpp
+            await this.ExecuteCommandAsync("update-alternatives", "--remove-all cpp", Environment.CurrentDirectory, telemetryContext, cancellationToken);
+
             // For some update path, the cpp can't be update-alternative by a gcc, so needs a separate call.
             string updateAlternativeArgumentCpp = $"--install /usr/bin/cpp cpp /usr/bin/cpp-{gccVersion} {gccVersion}0";
 

--- a/src/VirtualClient/VirtualClient.Dependencies/CompilerInstallation.cs
+++ b/src/VirtualClient/VirtualClient.Dependencies/CompilerInstallation.cs
@@ -242,8 +242,7 @@ namespace VirtualClient.Dependencies
             string[] packages =
             {
                 "gcc",
-                "gfortran",
-                "cpp"
+                "gfortran"
             };
 
             // due to the following error:
@@ -264,7 +263,7 @@ namespace VirtualClient.Dependencies
                 }
             }
         }
-
+ 
         private async Task SetGccPriorityAsync(string gccVersion, EventContext telemetryContext, CancellationToken cancellationToken)
         {
             string updateAlternativeArgument = $"--install /usr/bin/gcc gcc /usr/bin/gcc-{gccVersion} {gccVersion}0 " +


### PR DESCRIPTION
Resolving compiler installation bug as noted here: [https://msazure.visualstudio.com/One/_workitems/edit/30166784](https://msazure.visualstudio.com/One/_workitems/edit/30166784).

Added line to remove existing alternatives for cpp.

PERF-MEM-LMBENCH: Tested on Ubuntu 20.04 x64.
PERF-SPECCPU-FPRATE: Tested on Ubuntu 24.04 arm64. Second run doesn't result in error at the compiler installation step.