### PR TITLE
fixing namespace: VirtualClient.Dependencies.Packaging --> VirtualClient.Dependencies

### DIFF
--- a/src/VirtualClient/VirtualClient.Dependencies.UnitTests/Packaging/DependencyPackageInstallationTests.cs
+++ b/src/VirtualClient/VirtualClient.Dependencies.UnitTests/Packaging/DependencyPackageInstallationTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace VirtualClient.Dependencies.Packaging
+namespace VirtualClient.Dependencies
 {
     using System;
     using System.Collections.Generic;

--- a/src/VirtualClient/VirtualClient.Dependencies.UnitTests/Packaging/WgetPackageInstallationTests.cs
+++ b/src/VirtualClient/VirtualClient.Dependencies.UnitTests/Packaging/WgetPackageInstallationTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace VirtualClient.Dependencies.Packaging
+namespace VirtualClient.Dependencies
 {
     using System;
     using System.Collections.Generic;

--- a/src/VirtualClient/VirtualClient.Dependencies/JDKPackageDependencyInstallation.cs
+++ b/src/VirtualClient/VirtualClient.Dependencies/JDKPackageDependencyInstallation.cs
@@ -12,7 +12,6 @@ namespace VirtualClient.Dependencies
     using VirtualClient.Common.Extensions;
     using VirtualClient.Common.Telemetry;
     using VirtualClient.Contracts;
-    using VirtualClient.Dependencies.Packaging;
 
     /// <summary>
     /// Provides functionality for installing the JDK on the system.

--- a/src/VirtualClient/VirtualClient.Dependencies/Packaging/BlobPackageInstallation.cs
+++ b/src/VirtualClient/VirtualClient.Dependencies/Packaging/BlobPackageInstallation.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace VirtualClient.Dependencies.Packaging
+namespace VirtualClient.Dependencies
 {
     using System;
     using System.Collections.Generic;

--- a/src/VirtualClient/VirtualClient.Dependencies/Packaging/DependencyPackageInstallation.cs
+++ b/src/VirtualClient/VirtualClient.Dependencies/Packaging/DependencyPackageInstallation.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace VirtualClient.Dependencies.Packaging
+namespace VirtualClient.Dependencies
 {
     using System;
     using System.Collections.Generic;

--- a/src/VirtualClient/VirtualClient.Main/Program.cs
+++ b/src/VirtualClient/VirtualClient.Main/Program.cs
@@ -25,7 +25,6 @@ namespace VirtualClient
     using VirtualClient.Common.Extensions;
     using VirtualClient.Common.Telemetry;
     using VirtualClient.Configuration;
-    using VirtualClient.Dependencies.Packaging;
 
     /// <summary>
     /// The main entry point for the program


### PR DESCRIPTION
Minor fix. 

Removing the usage of namespace "VirtualClient.Dependencies.Packaging"
