### PR TITLE
Allowing proxy api info to save in ApiClientManager

### DIFF
--- a/src/VirtualClient/VirtualClient.Core.UnitTests/ApiClientManagerTests.cs
+++ b/src/VirtualClient/VirtualClient.Core.UnitTests/ApiClientManagerTests.cs
@@ -1,8 +1,11 @@
 namespace VirtualClient
 {
+    using System;
     using System.Collections.Generic;
+    using System.Linq;
     using NUnit.Framework;
     using VirtualClient.Contracts;
+    using VirtualClient.Contracts.Proxy;
 
     [TestFixture]
     [Category("Unit")]
@@ -106,6 +109,24 @@ namespace VirtualClient
 
             actualClient = clientManager.GetOrCreateApiClient("AnyServer", new ClientInstance("AnyServer", "1.2.3.5", ClientRole.Server));
             Assert.AreEqual($"http://1.2.3.5:4502/", actualClient.BaseUri.ToString());
+        }
+
+        [Test]
+        public void ApiClientManagerCreatesTheExpectedProxyApiClient()
+        {
+            Uri uri = new Uri("http://1.2.3.5:4502/");
+            ApiClientManager clientManager = new ApiClientManager();
+
+            Assert.IsEmpty(clientManager.GetProxyApiClients());
+
+            clientManager.GetOrCreateProxyApiClient("1", uri);
+            IProxyApiClient proxyClient = clientManager.GetProxyApiClient("1");
+            Assert.AreEqual(proxyClient.BaseUri, uri);
+
+            IEnumerable<IProxyApiClient> proxyList = clientManager.GetProxyApiClients();
+            Assert.IsNotEmpty(proxyList);
+
+            Assert.AreEqual(proxyList.FirstOrDefault().BaseUri, uri);
         }
     }
 }

--- a/src/VirtualClient/VirtualClient.Core/ApiClientManager.cs
+++ b/src/VirtualClient/VirtualClient.Core/ApiClientManager.cs
@@ -109,6 +109,23 @@ namespace VirtualClient
         }
 
         /// <summary>
+        /// Get all existing/cached Proxy API clients.
+        /// </summary>
+        /// <returns>
+        /// A set of <see cref="IProxyApiClient"/> that can be used to interface with Proxy API Endpoints.
+        /// </returns>
+        public IEnumerable<IProxyApiClient> GetProxyApiClients()
+        {
+            List<IProxyApiClient> clients = new List<IProxyApiClient>();
+            if (this.proxyApiClients.Any())
+            {
+                clients.AddRange(this.proxyApiClients.Values);
+            }
+
+            return clients;
+        }
+
+        /// <summary>
         /// Returns the effective port to use for hosting the API service. The port can be defined/overridden
         /// on the command line.
         /// </summary>

--- a/src/VirtualClient/VirtualClient.Core/IApiClientManager.cs
+++ b/src/VirtualClient/VirtualClient.Core/IApiClientManager.cs
@@ -41,6 +41,15 @@ namespace VirtualClient
         int GetApiPort(ClientInstance instance = null);
 
         /// <summary>
+        /// Get all an existing/cached proxy API client.
+        /// </summary>
+        /// <returns>
+        /// List of <see cref="IProxyApiClient"/> that can be used to interface with a target
+        /// Virtual Client proxy API service.
+        /// </returns>
+        IEnumerable<IProxyApiClient> GetProxyApiClients();
+
+        /// <summary>
         /// Gets an existing/cached proxy API client or creates a new one adding it to the cache.
         /// </summary>
         /// <param name="id">The ID of the proxy API client to use for lookups.</param>

--- a/src/VirtualClient/VirtualClient.Main/CommandBase.cs
+++ b/src/VirtualClient/VirtualClient.Main/CommandBase.cs
@@ -322,6 +322,8 @@ namespace VirtualClient
             IProfileManager profileManager = new ProfileManager();
             List <IBlobManager> blobStores = new List<IBlobManager>();
 
+            ApiClientManager apiClientManager = new ApiClientManager(this.ApiPorts);
+
             // The Virtual Client supports a proxy API interface. When a proxy API is used, all dependencies/blobs will be download
             // through the proxy endpoint. All content/files will be uploaded through the proxy endpoint. All telemetry will be uploaded
             // the proxy endpoint (with the exception of file logging which remains as-is). This enables Virtual Client to support disconnected
@@ -341,6 +343,9 @@ namespace VirtualClient
 
                 blobStores.Add(DependencyFactory.CreateProxyBlobManager(new DependencyProxyStore(DependencyBlobStore.Content, this.ProxyApiUri), contentSource?.ToString(), debugLogger));
                 blobStores.Add(DependencyFactory.CreateProxyBlobManager(new DependencyProxyStore(DependencyBlobStore.Packages, this.ProxyApiUri), packageSource?.ToString(), debugLogger));
+
+                // Enabling ApiClientManager to save Proxy API will allow downstream to access proxy endpoints as required.
+                apiClientManager.GetOrCreateProxyApiClient(Guid.NewGuid().ToString(), this.ProxyApiUri);
             }
             else
             {
@@ -355,10 +360,12 @@ namespace VirtualClient
                 }
             }
 
+            
+
             IServiceCollection dependencies = new ServiceCollection();
             dependencies.AddSingleton<PlatformSpecifics>(platformSpecifics);
             dependencies.AddSingleton<IApiManager>(apiManager);
-            dependencies.AddSingleton<IApiClientManager>(new ApiClientManager(this.ApiPorts));
+            dependencies.AddSingleton<IApiClientManager>();
             dependencies.AddSingleton<IConfiguration>(configuration);
             dependencies.AddSingleton<IDiskManager>(systemManagement.DiskManager);
             dependencies.AddSingleton<IExpressionEvaluator>(ProfileExpressionEvaluator.Instance);

--- a/src/VirtualClient/VirtualClient.Main/CommandBase.cs
+++ b/src/VirtualClient/VirtualClient.Main/CommandBase.cs
@@ -365,7 +365,7 @@ namespace VirtualClient
             IServiceCollection dependencies = new ServiceCollection();
             dependencies.AddSingleton<PlatformSpecifics>(platformSpecifics);
             dependencies.AddSingleton<IApiManager>(apiManager);
-            dependencies.AddSingleton<IApiClientManager>();
+            dependencies.AddSingleton<IApiClientManager>(apiClientManager);
             dependencies.AddSingleton<IConfiguration>(configuration);
             dependencies.AddSingleton<IDiskManager>(systemManagement.DiskManager);
             dependencies.AddSingleton<IExpressionEvaluator>(ProfileExpressionEvaluator.Instance);

--- a/src/VirtualClient/VirtualClient.TestFramework/InMemoryApiClientManager.cs
+++ b/src/VirtualClient/VirtualClient.TestFramework/InMemoryApiClientManager.cs
@@ -217,6 +217,14 @@ namespace VirtualClient
         }
 
         /// <summary>
+        /// Not implemented.
+        /// </summary>
+        public IEnumerable<IProxyApiClient> GetProxyApiClients()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Creates API clients from the ones that are already cached.
         /// </summary>
         /// <returns>


### PR DESCRIPTION
This PR allows VC to save proxy api safety. It can be further used downstream if required. 