### PR TITLE
Add conditional -k switch to CPS client command line

### DIFF
--- a/src/VirtualClient/VirtualClient.Actions/Network/NetworkingWorkload/CPS/CPSClientExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Network/NetworkingWorkload/CPS/CPSClientExecutor.cs
@@ -41,7 +41,7 @@ namespace VirtualClient.Actions.NetworkPerformance
             string clientIPAddress = this.GetLayoutClientInstances(ClientRole.Client).First().IPAddress;
             string serverIPAddress = this.GetLayoutClientInstances(ClientRole.Server).First().IPAddress;
 
-            return $"-c -r {this.Connections} " +
+            return $"-c -r {this.Connections} " + $"{((this.DataTransferMode == 2) ? "-k " : string.Empty)}" +
                 $"{clientIPAddress},0,{serverIPAddress},{this.Port},{this.ConnectionsPerThread},{this.MaxPendingRequestsPerThread},{this.ConnectionDuration},{this.DataTransferMode} " +
                 $"-i {this.DisplayInterval} -wt {this.WarmupTime} -t {this.TestDuration} " +
                 $"{((this.DelayTime != 0) ? $"-ds {this.DelayTime}" : string.Empty)}".Trim();


### PR DESCRIPTION
This switch is required to insert 2 seconds delay between send/receive when the data transfer mode is set to 2, which is continuous send/receive.