### PR TITLE
Fix Packaging/dockerfiles/linux-x64.dockerfile and update to use Ubuntu 22.04

### DIFF
--- a/src/VirtualClient/VirtualClient.Packaging/dockerfiles/linux-x64.dockerfile
+++ b/src/VirtualClient/VirtualClient.Packaging/dockerfiles/linux-x64.dockerfile
@@ -1,5 +1,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/runtime
-# Ubuntu 20.04 image.
-FROM ${REPO}:5.0.9-focal-amd64
+# Ubuntu 22.04 image.
+FROM ${REPO}:8.0-jammy-amd64
+# VirtualClient dependencies.
+RUN apt-get update -y && apt-get install -y lsb-release sudo wget gnupg
 
-COPY out/bin/Release/x64/VirtualClient.Main/net8.0/linux-x64/publish/. ./VirtualClient/
+COPY out/bin/Release/x64/VirtualClient.Main/net8.0/linux-x64/. ./VirtualClient/


### PR DESCRIPTION
It didn't work for me out of the box because the compiled VirtualClient binary wasn't in a publish subdirectory.

Some profiles's package installation actions require lsb-release, sudo, wget, and gnupg, so add them to the Dockerfile.

Update to Ubuntu 22.04 since that's what VirtualClient supports.