### PR TITLE
Fixing fio job file error

### DIFF
--- a/src/VirtualClient/VirtualClient.Actions/FIO/FioExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/FIO/FioExecutor.cs
@@ -980,7 +980,11 @@ namespace VirtualClient.Actions
 
             foreach (string key in this.Parameters.Keys)
             {
-                text = Regex.Replace(text, @$"\${{{key.ToLower()}}}", this.Parameters.GetValue<string>(key));
+                string value = this.Parameters.GetValue<string>(key);
+                if (!string.IsNullOrEmpty(value))
+                {
+                    text = Regex.Replace(text, @$"\${{{key.ToLower()}}}", value);
+                }
             }
 
             this.SystemManagement.FileSystem.File.WriteAllText(@destinationPath, text);


### PR DESCRIPTION
Observing this error in QoS VC for PERF-IO-FIO-OLTP.json:
One or more errors occurred. (Maximum Virtual Client restart-on-crash attempts reached (crashes = 6). stderr: [02/15/2025 09:10:19] Unexpected profile definition. Only one of JobFiles or CommandLine can be defined.\n\n   at VirtualClient.Actions.FioExecutor.Validate()\n   at VirtualClient.Contracts.VirtualClientComponent.<>c__DisplayClass130_1.<<ExecuteAsync>b__4>d.MoveNext()\n--- End of stack trace from previous location ---\n ...

This seems to occur on the second iteration of the workload during parameter validation. Changing the job file case to avoid setting the command line in that case.
Tested PERF-IO-FIO-OLTP and PERF-IO-FIO manually on VMs.