### PR TITLE
Move delay in WindowsPerformanceMonitor SnapshotCountersAsync

### DIFF
--- a/src/VirtualClient/VirtualClient.Monitors/PerformanceCounters/WindowsPerformanceCounterMonitor.cs
+++ b/src/VirtualClient/VirtualClient.Monitors/PerformanceCounters/WindowsPerformanceCounterMonitor.cs
@@ -324,8 +324,6 @@ namespace VirtualClient.Monitors
                 {
                     try
                     {
-                        await Task.Delay(this.MonitorFrequency, cancellationToken);
-
                         if (!cancellationToken.IsCancellationRequested)
                         {
                             List<Metric> metrics = new List<Metric>();
@@ -350,6 +348,8 @@ namespace VirtualClient.Monitors
                                 this.Logger.LogPerformanceCounters(".NET SDK", metrics, metrics.Min(m => m.StartTime), DateTime.UtcNow, telemetryContext);
                             }
                         }
+
+                        await Task.Delay(this.MonitorFrequency, cancellationToken);
                     }
                     catch (TaskCanceledException)
                     {


### PR DESCRIPTION
Move "MonitorFrequency" delay in WindowsPerformanceMonitor SnapshotCountersAsync to end of while loop. This ensures that when the first round of metrics to be taken we do not have to wait for "MonitorFrequency" before generating and emitting first round of metrics to telemetry.