### PR TITLE
Added initialization of retry policy for Networking Workload

### DIFF
--- a/src/VirtualClient/VirtualClient.Actions/Network/NetworkingWorkload/CPS/CPSExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Network/NetworkingWorkload/CPS/CPSExecutor.cs
@@ -33,17 +33,6 @@ namespace VirtualClient.Actions.NetworkPerformance
         {
             this.ProcessStartRetryPolicy = Policy.Handle<Exception>(exc => exc.Message.Contains("sockwiz")).Or<VirtualClientException>()
                 .WaitAndRetryAsync(5, retries => TimeSpan.FromSeconds(retries * 3));
-
-            this.Parameters.SetIfNotDefined(nameof(this.ConnectionDuration), 0);
-            this.Parameters.SetIfNotDefined(nameof(this.DataTransferMode), 1);
-            this.Parameters.SetIfNotDefined(nameof(this.DisplayInterval), 10);
-            this.Parameters.SetIfNotDefined(nameof(this.ConnectionsPerThread), 100);
-            this.Parameters.SetIfNotDefined(nameof(this.MaxPendingRequestsPerThread), 100);
-            this.Parameters.SetIfNotDefined(nameof(this.Port), 7201);
-            this.Parameters.SetIfNotDefined(nameof(this.WarmupTime), 8);
-            this.Parameters.SetIfNotDefined(nameof(this.DelayTime), 0);
-            this.Parameters.SetIfNotDefined(nameof(this.ConfidenceLevel), 99);
-            this.Parameters.SetIfNotDefined(nameof(this.AdditionalParams), string.Empty);
         }
 
         /// <summary>
@@ -57,17 +46,6 @@ namespace VirtualClient.Actions.NetworkPerformance
             this.fileSystem = dependencies.GetService<IFileSystem>();
             this.ProcessStartRetryPolicy = Policy.Handle<Exception>(exc => exc.Message.Contains("sockwiz")).Or<VirtualClientException>()
                 .WaitAndRetryAsync(5, retries => TimeSpan.FromSeconds(retries * 3));
-
-            this.Parameters.SetIfNotDefined(nameof(this.ConnectionDuration), 0);
-            this.Parameters.SetIfNotDefined(nameof(this.DataTransferMode), 1);
-            this.Parameters.SetIfNotDefined(nameof(this.DisplayInterval), 10);
-            this.Parameters.SetIfNotDefined(nameof(this.ConnectionsPerThread), 100);
-            this.Parameters.SetIfNotDefined(nameof(this.MaxPendingRequestsPerThread), 100);
-            this.Parameters.SetIfNotDefined(nameof(this.Port), 7201);
-            this.Parameters.SetIfNotDefined(nameof(this.WarmupTime), 8);
-            this.Parameters.SetIfNotDefined(nameof(this.DelayTime), 0);
-            this.Parameters.SetIfNotDefined(nameof(this.ConfidenceLevel), 99);
-            this.Parameters.SetIfNotDefined(nameof(this.AdditionalParams), string.Empty);
         }
 
         /// <summary>

--- a/src/VirtualClient/VirtualClient.Actions/Network/NetworkingWorkload/Latte/LatteExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Network/NetworkingWorkload/Latte/LatteExecutor.cs
@@ -29,6 +29,8 @@ namespace VirtualClient.Actions.NetworkPerformance
         public LatteExecutor(VirtualClientComponent component)
            : base(component)
         {
+            this.ProcessStartRetryPolicy = Policy.Handle<Exception>(exc => exc.Message.Contains("sockwiz_tcp_listener_open bind"))
+                .WaitAndRetryAsync(5, retries => TimeSpan.FromSeconds(retries * 3));
         }
 
         /// <summary>

--- a/src/VirtualClient/VirtualClient.Actions/Network/NetworkingWorkload/NTttcp/NTttcpExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Network/NetworkingWorkload/NTttcp/NTttcpExecutor.cs
@@ -34,6 +34,8 @@ namespace VirtualClient.Actions.NetworkPerformance
         public NTttcpExecutor(VirtualClientComponent component)
            : base(component)
         {
+            this.ProcessStartRetryPolicy = Policy.Handle<Exception>(exc => exc.Message.Contains("sockwiz_tcp_listener_open bind"))
+               .WaitAndRetryAsync(5, retries => TimeSpan.FromSeconds(retries * 3));
         }
 
         /// <summary>
@@ -46,9 +48,6 @@ namespace VirtualClient.Actions.NetworkPerformance
         {
             this.ProcessStartRetryPolicy = Policy.Handle<Exception>(exc => exc.Message.Contains("sockwiz_tcp_listener_open bind"))
                .WaitAndRetryAsync(5, retries => TimeSpan.FromSeconds(retries * 3));
-
-            this.Parameters.SetIfNotDefined(nameof(this.ThreadCount), 1);
-            this.Parameters.SetIfNotDefined(nameof(this.TestDuration), 60);
         }
 
         /// <summary>

--- a/src/VirtualClient/VirtualClient.Actions/Network/NetworkingWorkload/SockPerf/SockPerfExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Network/NetworkingWorkload/SockPerf/SockPerfExecutor.cs
@@ -29,6 +29,8 @@ namespace VirtualClient.Actions.NetworkPerformance
         public SockPerfExecutor(VirtualClientComponent component)
            : base(component)
         {
+            this.ProcessStartRetryPolicy = Policy.Handle<Exception>(exc => exc.Message.Contains("sockwiz_tcp_listener_open bind"))
+               .WaitAndRetryAsync(5, retries => TimeSpan.FromSeconds(retries * 3));
         }
 
         /// <summary>
@@ -41,10 +43,6 @@ namespace VirtualClient.Actions.NetworkPerformance
         {
             this.ProcessStartRetryPolicy = Policy.Handle<Exception>(exc => exc.Message.Contains("sockwiz_tcp_listener_open bind"))
                .WaitAndRetryAsync(5, retries => TimeSpan.FromSeconds(retries * 3));
-
-            this.Parameters.SetIfNotDefined(nameof(this.Port), 6100);
-            this.Parameters.SetIfNotDefined(nameof(this.MessagesPerSecond), "max");
-            this.Parameters.SetIfNotDefined(nameof(this.ConfidenceLevel), 99);
         }
 
         /// <summary>


### PR DESCRIPTION
- Added initialization of ProcessStartRetryPolicy in both constructors to handle null reference exceptions.
- Removed redundant default parameter settings in the constructor as they are already handled in the property getters.
