### PR TITLE
Modify ThreadCount for Prime95

### DIFF
--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-CPU-PRIME95.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-CPU-PRIME95.json
@@ -7,7 +7,7 @@
     },
     "Parameters": {
         "Duration": "00:15:00",
-        "ThreadCount": "{calculate({LogicalCoreCount} - 1)}"
+        "ThreadCount": "{calculate({PhysicalCoreCount} - 1)}"
     },
     "Actions": [
         {


### PR DESCRIPTION
With Hyperthread=1 and ThreadCount > Physical CoreCount, Prime95 is giving an error statement of:

Cannot initialize FFT code, errorcode 1010
Unknown gwnum error code: 1010

Either option is to set Hyperthread=0 or reduce the threadcount.

For full system stress (power, thermal and stability), hyperthread=1 and ThreadCount=PhysicalCoreCount is an optimum solution.