### PR TITLE
Suppressed wget certificate check in Compression Workload

### DIFF
--- a/src/VirtualClient/VirtualClient.Actions/7zip/Compression7zipExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/7zip/Compression7zipExecutor.cs
@@ -119,7 +119,7 @@ namespace VirtualClient.Actions
                 // Choose default file for compression and decompression if files/dirs are not provided.
                 if (string.IsNullOrWhiteSpace(this.InputFilesOrDirs))
                 {
-                    await this.ExecuteCommandAsync("wget", $"https://sun.aei.polsl.pl//~sdeor/corpus/silesia.zip", this.Compressor7zipDirectory, cancellationToken);
+                    await this.ExecuteCommandAsync("wget", $"--no-check-certificate https://sun.aei.polsl.pl//~sdeor/corpus/silesia.zip", this.Compressor7zipDirectory, cancellationToken);
                     await this.ExecuteCommandAsync("unzip", "silesia.zip -d silesia", this.Compressor7zipDirectory, cancellationToken);
                 }
 

--- a/website/docs/workloads/hplinpack/hplinpack-profiles.md
+++ b/website/docs/workloads/hplinpack/hplinpack-profiles.md
@@ -79,14 +79,15 @@ This profile is designed to identify general/broad regressions when compared aga
 
   ```
 
+* 
   * **Performance Library Parameter set**  
   The following parameter sets are supported.
 
   | Platform                 | PerformanceLibrary          |        PerformanceLibraryVersion              |  CompilerName   |  CompilerVersion  |  Commandline Usage  |
-  |--------------------------|-----------------------------|-----------------------------------------------|------------|------------|
-  |   arm64 | ARM | 23.04.1, 24.10 and 25.04.1 | gcc | 11 |  --parameters=PerformanceLibrary=ARM,,,PerformanceLibraryVersion=23.04.10,,,CompilerName=gcc,,,CompilerVersion=11 |
-  |   x64 | AMD  | 4.2.0, 5.0.0, 5.1.0 | gcc | 11 |   --parameters=PerformanceLibrary=AMD,,,PerformanceLibraryVersion=4.2.0,,,CompilerName=gcc,,,CompilerVersion=11 |
-  |   x64 | INTEL  | 2024.2.2.17, 2025.1.0.803 | gcc | 13 |   --parameters=PerformanceLibrary=INTEL,,,PerformanceLibraryVersion=2024.2.2.17,,,CompilerVersion=13 |
+  |--------------------------|-----------------------------|-----------------------------------------------|-----------------|-------------------|---------------------|
+  |   arm64 | ARM    | 23.04.1, 24.10 and 25.04.1 | gcc | 11 |  --parameters=PerformanceLibrary=ARM,,,PerformanceLibraryVersion=23.04.10,,,CompilerName=gcc,,,CompilerVersion=11 |
+  |   x64   | AMD    | 4.2.0, 5.0.0, 5.1.0        | gcc | 11 |   --parameters=PerformanceLibrary=AMD,,,PerformanceLibraryVersion=4.2.0,,,CompilerName=gcc,,,CompilerVersion=11 |
+  |   x64   | INTEL  | 2024.2.2.17, 2025.1.0.803  | gcc | 13 |   --parameters=PerformanceLibrary=INTEL,,,PerformanceLibraryVersion=2024.2.2.17,,,CompilerVersion=13 |
 
 * **Resources**
 


### PR DESCRIPTION
Addressing Compression workload failure in windows.

- Suppressed by adding '--no-check-certificate' flag to wget command.
- Also fixed documentation error in HPLinpack.