### PR TITLE
Refactor disk mounting logic to set full permissions on disks.

### DIFF
--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/Prime95/Prime95ExecutorTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/Prime95/Prime95ExecutorTests.cs
@@ -167,12 +167,12 @@ namespace VirtualClient.Actions
         }
 
         [Test]
-        [TestCase(PlatformID.Win32NT, @"\win-x64\results.txt")]
-        [TestCase(PlatformID.Unix, @"/linux-x64/results.txt")]
-        public void Prime95ExecutorThrowsWhenWorkloadResultsFileNotFound(PlatformID platform, string resultsPath)
+        [TestCase(PlatformID.Win32NT)]
+        [TestCase(PlatformID.Unix)]
+        public void Prime95ExecutorThrowsWhenWorkloadResultsFileNotFound(PlatformID platform)
         {
             this.SetupTest(platform);
-            this.mockFixture.File.Setup(fe => fe.Exists(this.mockPackage.Path + resultsPath))
+            this.mockFixture.File.Setup(fe => fe.Exists(It.Is<string>(file => file.EndsWith("results.txt"))))
                 .Returns(false);
 
             using (TestPrime95Executor executor = new TestPrime95Executor(this.mockFixture))

--- a/src/VirtualClient/VirtualClient.Actions/Sysbench/SysbenchConfiguration.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Sysbench/SysbenchConfiguration.cs
@@ -5,9 +5,6 @@ namespace VirtualClient.Actions
 {
     using System;
     using System.Collections.Generic;
-    using System.ComponentModel;
-    using System.Linq;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;

--- a/src/VirtualClient/VirtualClient.Actions/Sysbench/SysbenchExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Sysbench/SysbenchExecutor.cs
@@ -42,11 +42,6 @@ namespace VirtualClient.Actions
         protected const string PythonCommand = "python3";
 
         private readonly IStateManager stateManager;
-        private static readonly string[] SelectWorkloads =
-        {
-            "select_random_points",
-            "select_random_ranges"
-        };
 
         /// <summary>
         /// Constructor for <see cref="SysbenchExecutor"/>
@@ -65,7 +60,7 @@ namespace VirtualClient.Actions
         }
 
         /// <summary>
-        /// The database name option passed to Sysbench.
+        /// The benchmark (e.g. OLTP, TPCC).
         /// </summary>
         public string Benchmark
         {
@@ -111,7 +106,7 @@ namespace VirtualClient.Actions
         }
 
         /// <summary>
-        /// The workload option passed to Sysbench.
+        /// The number of tables to create in the database.
         /// </summary>
         public int? TableCount
         {
@@ -135,7 +130,7 @@ namespace VirtualClient.Actions
         }
 
         /// <summary>
-        /// Number of records per table.
+        /// The database system (e.g. MySQL, PostgreSQL).
         /// </summary>
         public string DatabaseSystem
         {
@@ -158,7 +153,7 @@ namespace VirtualClient.Actions
         }
 
         /// <summary>
-        /// Number of records per table.
+        /// Number of warehouses.
         /// </summary>
         public int? WarehouseCount
         {
@@ -170,7 +165,7 @@ namespace VirtualClient.Actions
         }
 
         /// <summary>
-        /// The workload option passed to Sysbench.
+        /// The workload option passed to Sysbench (e.g. oltp_update_index, oltp_update_non_index).
         /// </summary>
         public string Workload
         {
@@ -252,7 +247,6 @@ namespace VirtualClient.Actions
             recordCountExponent = Math.Max(3, recordCountExponent);
 
             int recordEstimate = (int)Math.Pow(10, recordCountExponent);
-
             int recordCount = records.GetValueOrDefault(recordEstimate);
 
             // record count specified in profile if it is the configurable scenario

--- a/src/VirtualClient/VirtualClient.Contracts.UnitTests/PlatformSpecificsTests.cs
+++ b/src/VirtualClient/VirtualClient.Contracts.UnitTests/PlatformSpecificsTests.cs
@@ -64,6 +64,62 @@ namespace VirtualClient.Contracts
         }
 
         [Test]
+        public void GetLoggedInUserReturnsTheExpectedUserOnWindowsSystems()
+        {
+            PlatformSpecifics platformSpecifics = new TestPlatformSpecifics(PlatformID.Win32NT, Architecture.X64);
+            string user = platformSpecifics.GetLoggedInUser();
+            Assert.AreEqual(Environment.UserName, user);
+
+            platformSpecifics.SetEnvironmentVariable(EnvironmentVariable.SUDO_USER, "User01");
+        }
+
+        [Test]
+        public void GetLoggedInUserReturnsTheExpectedUserOnWindowsSystems_2()
+        {
+            // Environment variables do not matter on Windows and should not affect
+            // the return user.
+            PlatformSpecifics platformSpecifics = new TestPlatformSpecifics(PlatformID.Win32NT, Architecture.X64);
+
+            platformSpecifics.SetEnvironmentVariable(EnvironmentVariable.SUDO_USER, "User01");
+            string user = platformSpecifics.GetLoggedInUser();
+            Assert.AreEqual(Environment.UserName, user);
+
+            platformSpecifics.SetEnvironmentVariable(EnvironmentVariable.VC_SUDO_USER, "User02");
+            user = platformSpecifics.GetLoggedInUser();
+            Assert.AreEqual(Environment.UserName, user);
+        }
+
+        [Test]
+        public void GetLoggedInUserReturnsTheExpectedUserOnUnixSystems()
+        {
+            PlatformSpecifics platformSpecifics = new TestPlatformSpecifics(PlatformID.Unix, Architecture.X64);
+            string user = platformSpecifics.GetLoggedInUser();
+            Assert.AreEqual(Environment.UserName, user);
+        }
+
+        [Test]
+        public void GetLoggedInUserReturnsTheExpectedUserOnUnixSystemsWhenSudoIsUsed()
+        {
+            PlatformSpecifics platformSpecifics = new TestPlatformSpecifics(PlatformID.Unix, Architecture.X64);
+
+            string sudoUser = "User01";
+            platformSpecifics.SetEnvironmentVariable(EnvironmentVariable.SUDO_USER, sudoUser);
+            string user = platformSpecifics.GetLoggedInUser();
+            Assert.AreEqual(sudoUser, user);
+        }
+
+        [Test]
+        public void GetLoggedInUserReturnsTheExpectedUserOnUnixSystemsWhenCustomSudoAlternativesAreUsed()
+        {
+            PlatformSpecifics platformSpecifics = new TestPlatformSpecifics(PlatformID.Unix, Architecture.X64);
+
+            string sudoUser = "User01";
+            platformSpecifics.SetEnvironmentVariable(EnvironmentVariable.VC_SUDO_USER, sudoUser);
+            string user = platformSpecifics.GetLoggedInUser();
+            Assert.AreEqual(sudoUser, user);
+        }
+
+        [Test]
         public void GetPackagePathReturnsTheExpectedPathOnWindowsSystems()
         {
             PlatformSpecifics platformSpecifics = new TestPlatformSpecifics2(PlatformID.Win32NT, Architecture.X64, @"C:\users\anyuser\virtualclient");

--- a/src/VirtualClient/VirtualClient.Contracts/FileContext.cs
+++ b/src/VirtualClient/VirtualClient.Contracts/FileContext.cs
@@ -16,6 +16,8 @@ namespace VirtualClient.Contracts
     /// </summary>
     public class FileContext
     {
+        private const string FileTimestampFormat = "yyyy-MM-ddTHH-mm-ss-fffffK";
+        private static readonly Regex PathReservedCharacterExpression = new Regex(@"[""<>:|?*\\/]+", RegexOptions.Compiled);
         private static readonly Regex TemplatePlaceholderExpression = new Regex(@"\{(.*?)\}", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         /// <summary>
@@ -93,6 +95,19 @@ namespace VirtualClient.Contracts
         /// The name of the tool/toolset that produced the file (e.g. FioExecutor, FIO).
         /// </summary>
         public string ToolName { get; }
+
+        /// <summary>
+        /// Returns a file name containing a timestamp as part of the name having removed any
+        /// characters not allowed in file paths (e.g. 2023-02-01T12-23-30241Z-randomwrite_4k_blocksize.log).
+        /// </summary>
+        /// <param name="fileName">The name of the file (e.g. randomwrite_4k_blocksize.log)</param>
+        /// <param name="timestamp">The timestamp to add to the file name.</param>
+        public static string GetFileName(string fileName, DateTime timestamp)
+        {
+            return PathReservedCharacterExpression.Replace(
+                $"{timestamp.ToString(FileTimestampFormat)}-{fileName.RemoveWhitespace()}",
+                string.Empty);
+        }
 
         /// <summary>
         /// Resolves placeholders in the path template provided.

--- a/src/VirtualClient/VirtualClient.Contracts/FileUploadDescriptor.cs
+++ b/src/VirtualClient/VirtualClient.Contracts/FileUploadDescriptor.cs
@@ -24,9 +24,6 @@ namespace VirtualClient.Contracts
         /// The default extension for the file uploads.
         /// </summary>
         public const string UploadDescriptorFileExtension = "upload.json";
-
-        private const string FileTimestampFormat = "yyyy-MM-ddTHH-mm-ss-fffffK";
-        private static readonly Regex PathReservedCharacterExpression = new Regex(@"[""<>:|?*\\/]+", RegexOptions.Compiled);
         private static readonly char[] PathDelimiters = new char[] { '/', '\\' };
 
         /// <summary>
@@ -171,19 +168,6 @@ namespace VirtualClient.Contracts
             }
 
             return fileManifest.ObscureSecrets();
-        }
-
-        /// <summary>
-        /// Returns a file name containing a timestamp as part of the name having removed any
-        /// characters not allowed in file paths (e.g. 2023-02-01T12-23-30241Z-randomwrite_4k_blocksize.log).
-        /// </summary>
-        /// <param name="fileName">The name of the file (e.g. randomwrite_4k_blocksize.log)</param>
-        /// <param name="timestamp">The timestamp to add to the file name.</param>
-        public static string GetFileName(string fileName, DateTime timestamp)
-        {
-            return PathReservedCharacterExpression.Replace(
-                $"{timestamp.ToString(FileTimestampFormat)}-{fileName.RemoveWhitespace()}",
-                string.Empty);
         }
 
         /// <summary>

--- a/src/VirtualClient/VirtualClient.Contracts/FileUploadDescriptorFactory.cs
+++ b/src/VirtualClient/VirtualClient.Contracts/FileUploadDescriptorFactory.cs
@@ -62,7 +62,7 @@ namespace VirtualClient.Contracts
 
             if (timestamped)
             {
-                blobName = FileUploadDescriptor.GetFileName(blobName, fileContext.File.CreationTimeUtc);
+                blobName = FileContext.GetFileName(blobName, fileContext.File.CreationTimeUtc);
             }
 
             // The caller of this factory method makes the determination on the runtime parameters that are 

--- a/src/VirtualClient/VirtualClient.Contracts/PlatformSpecifics.cs
+++ b/src/VirtualClient/VirtualClient.Contracts/PlatformSpecifics.cs
@@ -453,18 +453,19 @@ namespace VirtualClient.Contracts
         public string GetLoggedInUser()
         {
             string loggedInUserName = Environment.UserName;
-            if (string.Equals(loggedInUserName, "root"))
+            if (this.Platform == PlatformID.Unix)
             {
-                loggedInUserName = this.GetEnvironmentVariable(EnvironmentVariable.SUDO_USER);
-                if (string.IsNullOrWhiteSpace(loggedInUserName))
+                // Note that when the user is "root" and running a command with "sudo", there will be
+                // no "SUDO_USER" environment variable.
+                string sudoUser = this.GetEnvironmentVariable(EnvironmentVariable.SUDO_USER);
+                if (string.IsNullOrWhiteSpace(sudoUser))
                 {
-                    loggedInUserName = this.GetEnvironmentVariable(EnvironmentVariable.VC_SUDO_USER);
-                    if (string.IsNullOrEmpty(loggedInUserName))
-                    {
-                        // When the user is "root" and running a command with "sudo", there will be
-                        // no "SUDO_USER" environment variable.
-                        return "root";
-                    }
+                    sudoUser = this.GetEnvironmentVariable(EnvironmentVariable.VC_SUDO_USER);
+                }
+
+                if (!string.IsNullOrEmpty(sudoUser))
+                {
+                    return sudoUser;
                 }
             }
 

--- a/src/VirtualClient/VirtualClient.Contracts/VirtualClientComponentExtensions.cs
+++ b/src/VirtualClient/VirtualClient.Contracts/VirtualClientComponentExtensions.cs
@@ -378,7 +378,7 @@ namespace VirtualClient.Contracts
                         fileSystem.Directory.CreateDirectory(targetDirectory);
                     }
 
-                    string fileName = FileUploadDescriptor.GetFileName(FileUploadDescriptor.UploadDescriptorFileExtension, DateTime.UtcNow);
+                    string fileName = FileContext.GetFileName(FileUploadDescriptor.UploadDescriptorFileExtension, DateTime.UtcNow);
                     string filePath = component.Combine(targetDirectory, fileName.ToLowerInvariant());
 
                     await fileSystem.File.WriteAllTextAsync(filePath, descriptor.ToJson());

--- a/src/VirtualClient/VirtualClient.Core/Logging/Console/ConsoleLogger.cs
+++ b/src/VirtualClient/VirtualClient.Core/Logging/Console/ConsoleLogger.cs
@@ -41,7 +41,7 @@ namespace VirtualClient.Logging
         /// <summary>
         /// The default console logger.
         /// </summary>
-        public static ConsoleLogger Default { get; set; } = new ConsoleLogger("VirtualClient", LogLevel.Debug);
+        public static ConsoleLogger Default { get; set; } = new ConsoleLogger("VirtualClient", LogLevel.Trace);
 
         /// <summary>
         /// True to include log severity levels in output.

--- a/src/VirtualClient/VirtualClient.Core/UnixDiskManager.cs
+++ b/src/VirtualClient/VirtualClient.Core/UnixDiskManager.cs
@@ -9,7 +9,6 @@ namespace VirtualClient
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.Logging;
-    using Org.BouncyCastle.Pqc.Crypto.Lms;
     using Polly;
     using VirtualClient.Common;
     using VirtualClient.Common.Extensions;
@@ -21,33 +20,6 @@ namespace VirtualClient
     /// </summary>
     public class UnixDiskManager : DiskManager
     {
-        private const string BusInfo = "businfo";
-        private const string Capacity = "capacity";
-        private const string Capabilities = "capabilities";
-        private const string Claimed = "claimed";
-        private const string Class = "class";
-        private const string Device = "dev";
-        private const string Description = "description";
-        private const string FileSystem = "filesystem";
-        private const string Handle = "handle";
-        private const string Id = "id";
-        private const string LogicalName = "logicalname";
-        private const string PhysicalId = "physid";
-        private const string Product = "product";
-        private const string Serial = "serial";
-        private const string Size = "size";
-        private const string Vendor = "vendor";
-        private const string Version = "version";
-
-        // Key   = The mount point/path
-        // Value = The relative priority in relation to other paths or mount points when accessing the disk. < 0 = not typically accessible.
-        private static readonly Dictionary<string, int> SystemDefinedMountPoints = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
-        {
-            { "/", 100 },
-            { "/mnt", 100 },
-            { "/boot/efi", -1 } // Not typically accessible
-        };
-
         /// <summary>
         /// Initializes a new instance of the <see cref="UnixDiskManager"/> class.
         /// </summary>

--- a/src/VirtualClient/VirtualClient.Dependencies.UnitTests/MountDisksTests.cs
+++ b/src/VirtualClient/VirtualClient.Dependencies.UnitTests/MountDisksTests.cs
@@ -38,10 +38,10 @@ namespace VirtualClient.Dependencies
                 foreach (DiskVolume diskVolume in this.diskVolumes)
                 {
                     // e.g.
-                    // /mnt_dev_sdc1
-                    // /mnt_dev_sdd1
-                    // /mnt_dev_sdd2
-                    string expectedMountPoint = $"/{diskVolume.GetDefaultMountPointName()}";
+                    // /home/user/mnt_dev_sdc1
+                    // /home/user/mnt_dev_sdd1
+                    // /home/user/mnt_dev_sdd2
+                    string expectedMountPoint = $"/home/{Environment.UserName}/{diskVolume.GetDefaultMountPointName()}";
                     this.mockFixture.DiskManager.Verify(mgr => mgr.CreateMountPointAsync(diskVolume, expectedMountPoint, It.IsAny<CancellationToken>()));
                 }
             }
@@ -60,7 +60,74 @@ namespace VirtualClient.Dependencies
 
                 foreach (DiskVolume diskVolume in this.diskVolumes)
                 {
+                    string expectedMountPoint = $"/home/{Environment.UserName}/{diskVolume.GetDefaultMountPointName()}";
+                    this.mockFixture.DiskManager.Verify(mgr => mgr.CreateMountPointAsync(diskVolume, expectedMountPoint, It.IsAny<CancellationToken>()));
+                }
+            }
+        }
+
+        [Test]
+        public async Task MountDisksHandlesCasesWhenRunningOnUnixWithSudo()
+        {
+            this.SetupTest(PlatformID.Unix);
+
+            using (MountDisks diskMounter = new MountDisks(this.mockFixture.Dependencies, this.mockFixture.Parameters))
+            {
+                diskMounter.PlatformSpecifics.SetEnvironmentVariable(EnvironmentVariable.SUDO_USER, "user01");
+                await diskMounter.ExecuteAsync(CancellationToken.None);
+
+                foreach (DiskVolume diskVolume in this.diskVolumes)
+                {
+                    // e.g.
+                    // /home/user01/mnt_dev_sdc1
+                    // /home/user01/mnt_dev_sdd1
+                    // /home/user01/mnt_dev_sdd2
+                    string expectedMountPoint = $"/home/user01/{diskVolume.GetDefaultMountPointName()}";
+                    this.mockFixture.DiskManager.Verify(mgr => mgr.CreateMountPointAsync(diskVolume, expectedMountPoint, It.IsAny<CancellationToken>()));
+                }
+            }
+        }
+
+        [Test]
+        public async Task MountDisksHandlesCasesWhenRunningOnUnixAsRoot()
+        {
+            this.SetupTest(PlatformID.Unix);
+
+            using (MountDisks diskMounter = new MountDisks(this.mockFixture.Dependencies, this.mockFixture.Parameters))
+            {
+                // SUDO_USER will be set to "root" when logged in as root.
+                diskMounter.PlatformSpecifics.SetEnvironmentVariable(EnvironmentVariable.SUDO_USER, "root");
+                await diskMounter.ExecuteAsync(CancellationToken.None);
+
+                foreach (DiskVolume diskVolume in this.diskVolumes)
+                {
+                    // e.g.
+                    // /mnt_dev_sdc1
+                    // /mnt_dev_sdd1
+                    // /mnt_dev_sdd2
                     string expectedMountPoint = $"/{diskVolume.GetDefaultMountPointName()}";
+                    this.mockFixture.DiskManager.Verify(mgr => mgr.CreateMountPointAsync(diskVolume, expectedMountPoint, It.IsAny<CancellationToken>()));
+                }
+            }
+        }
+
+        [Test]
+        [TestCase("mount_points")]
+        [TestCase("/mount_points")]
+        [TestCase("/mount_points/")]
+        [TestCase("  /mount_points/  ")]
+        public async Task MountDisksMountsTheExpectedPathOnUnixWhenAMountLocationIsProvided(string expectedMountLocation)
+        {
+            this.SetupTest(PlatformID.Unix);
+            this.mockFixture.Parameters["MountLocation"] = expectedMountLocation;
+
+            using (MountDisks diskMounter = new MountDisks(this.mockFixture.Dependencies, this.mockFixture.Parameters))
+            {
+                await diskMounter.ExecuteAsync(CancellationToken.None);
+
+                foreach (DiskVolume diskVolume in this.diskVolumes)
+                {
+                    string expectedMountPoint = $"/{expectedMountLocation.Trim().Trim('/')}/{diskVolume.GetDefaultMountPointName()}";
                     this.mockFixture.DiskManager.Verify(mgr => mgr.CreateMountPointAsync(diskVolume, expectedMountPoint, It.IsAny<CancellationToken>()));
                 }
             }
@@ -78,7 +145,7 @@ namespace VirtualClient.Dependencies
 
                 foreach (DiskVolume diskVolume in this.diskVolumes)
                 {
-                    string expectedMountPoint = $"/{diskVolume.GetDefaultMountPointName(prefix: "mnt_test")}";
+                    string expectedMountPoint = $"/home/{Environment.UserName}/{diskVolume.GetDefaultMountPointName(prefix: "mnt_test")}";
                     this.mockFixture.DiskManager.Verify(mgr => mgr.CreateMountPointAsync(diskVolume, expectedMountPoint, It.IsAny<CancellationToken>()));
                 }
             }
@@ -95,8 +162,31 @@ namespace VirtualClient.Dependencies
 
                 foreach (DiskVolume diskVolume in this.diskVolumes)
                 {
+                    string expectedUser = Environment.UserName;
+                    string expectedDirectory = $"/home/{Environment.UserName}/{diskVolume.GetDefaultMountPointName()}";
+                    Assert.IsTrue(this.mockFixture.ProcessManager.CommandsExecuted($"chmod -R 777 \"{expectedDirectory}\""));
+                    Assert.IsTrue(this.mockFixture.ProcessManager.CommandsExecuted($"chown {expectedUser}:{expectedUser} \"{expectedDirectory}\""));
+                }
+            }
+        }
+
+        [Test]
+        public async Task MountDisksSetsExpectedPermissionsOnTheMountPointDirectoryOnUnixSystemsWhenRunningAsRoot()
+        {
+            this.SetupTest(PlatformID.Unix);
+
+            using (MountDisks diskMounter = new MountDisks(this.mockFixture.Dependencies, this.mockFixture.Parameters))
+            {
+                // SUDO_USER will be set to "root" when logged in as root.
+                diskMounter.PlatformSpecifics.SetEnvironmentVariable(EnvironmentVariable.SUDO_USER, "root");
+                await diskMounter.ExecuteAsync(CancellationToken.None);
+
+                foreach (DiskVolume diskVolume in this.diskVolumes)
+                {
+                    string expectedUser = "root";
                     string expectedDirectory = $"/{diskVolume.GetDefaultMountPointName()}";
-                    Assert.IsTrue(this.mockFixture.ProcessManager.CommandsExecuted($"chmod -R 2777 \"{expectedDirectory}\""));
+                    Assert.IsTrue(this.mockFixture.ProcessManager.CommandsExecuted($"chmod -R 777 \"{expectedDirectory}\""));
+                    Assert.IsTrue(this.mockFixture.ProcessManager.CommandsExecuted($"chown {expectedUser}:{expectedUser} \"{expectedDirectory}\""));
                 }
             }
         }
@@ -112,7 +202,7 @@ namespace VirtualClient.Dependencies
 
                 foreach (DiskVolume diskVolume in this.diskVolumes)
                 {
-                    string expectedMountPoint = this.mockFixture.Combine(diskVolume.DevicePath, diskVolume.GetDefaultMountPointName());
+                    string expectedMountPoint = this.mockFixture.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), diskVolume.GetDefaultMountPointName());
                     this.mockFixture.DiskManager.Verify(mgr => mgr.CreateMountPointAsync(diskVolume, expectedMountPoint, It.IsAny<CancellationToken>()));
                 }
             }
@@ -131,7 +221,28 @@ namespace VirtualClient.Dependencies
 
                 foreach (DiskVolume diskVolume in this.diskVolumes)
                 {
-                    string expectedMountPoint = this.mockFixture.Combine(diskVolume.DevicePath, diskVolume.GetDefaultMountPointName());
+                    string expectedMountPoint = this.mockFixture.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), diskVolume.GetDefaultMountPointName());
+                    this.mockFixture.DiskManager.Verify(mgr => mgr.CreateMountPointAsync(diskVolume, expectedMountPoint, It.IsAny<CancellationToken>()));
+                }
+            }
+        }
+
+        [Test]
+        [TestCase("C:\\mount_points")]
+        [TestCase("C:\\mount_points\\")]
+        [TestCase("  C:\\mount_points\\  ")]
+        public async Task MountDisksMountsTheExpectedPathOnWindowsWhenAMountLocationIsProvided(string expectedMountLocation)
+        {
+            this.SetupTest(PlatformID.Win32NT);
+            this.mockFixture.Parameters["MountLocation"] = expectedMountLocation;
+
+            using (MountDisks diskMounter = new MountDisks(this.mockFixture.Dependencies, this.mockFixture.Parameters))
+            {
+                await diskMounter.ExecuteAsync(CancellationToken.None);
+
+                foreach (DiskVolume diskVolume in this.diskVolumes)
+                {
+                    string expectedMountPoint = $@"{expectedMountLocation.Trim().Trim('\\')}\{diskVolume.GetDefaultMountPointName()}";
                     this.mockFixture.DiskManager.Verify(mgr => mgr.CreateMountPointAsync(diskVolume, expectedMountPoint, It.IsAny<CancellationToken>()));
                 }
             }
@@ -149,7 +260,7 @@ namespace VirtualClient.Dependencies
 
                 foreach (DiskVolume diskVolume in this.diskVolumes)
                 {
-                    string expectedMountPoint = this.mockFixture.Combine(diskVolume.DevicePath, diskVolume.GetDefaultMountPointName(prefix: "mnt_test"));
+                    string expectedMountPoint = this.mockFixture.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), diskVolume.GetDefaultMountPointName(prefix: "mnt_test"));
                     this.mockFixture.DiskManager.Verify(mgr => mgr.CreateMountPointAsync(diskVolume, expectedMountPoint, It.IsAny<CancellationToken>()));
                 }
             }

--- a/src/VirtualClient/VirtualClient.Dependencies.UnitTests/MountDisksTests.cs
+++ b/src/VirtualClient/VirtualClient.Dependencies.UnitTests/MountDisksTests.cs
@@ -37,9 +37,11 @@ namespace VirtualClient.Dependencies
 
                 foreach (DiskVolume diskVolume in this.diskVolumes)
                 {
-                    string expectedMountDirectory = this.mockFixture.StandardizePath(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
-                    string expectedMountPoint = this.mockFixture.Combine(expectedMountDirectory, diskVolume.GetDefaultMountPointName());
-
+                    // e.g.
+                    // /mnt_dev_sdc1
+                    // /mnt_dev_sdd1
+                    // /mnt_dev_sdd2
+                    string expectedMountPoint = $"/{diskVolume.GetDefaultMountPointName()}";
                     this.mockFixture.DiskManager.Verify(mgr => mgr.CreateMountPointAsync(diskVolume, expectedMountPoint, It.IsAny<CancellationToken>()));
                 }
             }
@@ -58,9 +60,7 @@ namespace VirtualClient.Dependencies
 
                 foreach (DiskVolume diskVolume in this.diskVolumes)
                 {
-                    string expectedMountDirectory = this.mockFixture.StandardizePath(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
-                    string expectedMountPoint = this.mockFixture.Combine(expectedMountDirectory, diskVolume.GetDefaultMountPointName());
-
+                    string expectedMountPoint = $"/{diskVolume.GetDefaultMountPointName()}";
                     this.mockFixture.DiskManager.Verify(mgr => mgr.CreateMountPointAsync(diskVolume, expectedMountPoint, It.IsAny<CancellationToken>()));
                 }
             }
@@ -78,22 +78,16 @@ namespace VirtualClient.Dependencies
 
                 foreach (DiskVolume diskVolume in this.diskVolumes)
                 {
-                    string expectedMountDirectory = this.mockFixture.StandardizePath(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
-
-                    string expectedMountPoint = this.mockFixture.Combine(
-                        expectedMountDirectory, 
-                        diskVolume.GetDefaultMountPointName(prefix: "mnt_test"));
-
+                    string expectedMountPoint = $"/{diskVolume.GetDefaultMountPointName(prefix: "mnt_test")}";
                     this.mockFixture.DiskManager.Verify(mgr => mgr.CreateMountPointAsync(diskVolume, expectedMountPoint, It.IsAny<CancellationToken>()));
                 }
             }
         }
 
         [Test]
-        public async Task MountDisksMountsTheExpectedPathOnUnixWhenAMountLocationIsProvided_Root()
+        public async Task MountDisksSetsExpectedPermissionsOnTheMountPointDirectoryOnUnixSystems()
         {
             this.SetupTest(PlatformID.Unix);
-            this.mockFixture.Parameters["MountLocation"] = "Root";
 
             using (MountDisks diskMounter = new MountDisks(this.mockFixture.Dependencies, this.mockFixture.Parameters))
             {
@@ -101,8 +95,8 @@ namespace VirtualClient.Dependencies
 
                 foreach (DiskVolume diskVolume in this.diskVolumes)
                 {
-                    string expectedMountPoint = this.mockFixture.Combine("/", diskVolume.GetDefaultMountPointName());
-                    this.mockFixture.DiskManager.Verify(mgr => mgr.CreateMountPointAsync(diskVolume, expectedMountPoint, It.IsAny<CancellationToken>()));
+                    string expectedDirectory = $"/{diskVolume.GetDefaultMountPointName()}";
+                    Assert.IsTrue(this.mockFixture.ProcessManager.CommandsExecuted($"chmod -R 2777 \"{expectedDirectory}\""));
                 }
             }
         }
@@ -118,9 +112,7 @@ namespace VirtualClient.Dependencies
 
                 foreach (DiskVolume diskVolume in this.diskVolumes)
                 {
-                    string expectedMountDirectory = this.mockFixture.StandardizePath(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
-                    string expectedMountPoint = this.mockFixture.Combine(expectedMountDirectory, diskVolume.GetDefaultMountPointName());
-
+                    string expectedMountPoint = this.mockFixture.Combine(diskVolume.DevicePath, diskVolume.GetDefaultMountPointName());
                     this.mockFixture.DiskManager.Verify(mgr => mgr.CreateMountPointAsync(diskVolume, expectedMountPoint, It.IsAny<CancellationToken>()));
                 }
             }
@@ -139,9 +131,7 @@ namespace VirtualClient.Dependencies
 
                 foreach (DiskVolume diskVolume in this.diskVolumes)
                 {
-                    string expectedMountDirectory = this.mockFixture.StandardizePath(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
-                    string expectedMountPoint = this.mockFixture.Combine(expectedMountDirectory, diskVolume.GetDefaultMountPointName());
-
+                    string expectedMountPoint = this.mockFixture.Combine(diskVolume.DevicePath, diskVolume.GetDefaultMountPointName());
                     this.mockFixture.DiskManager.Verify(mgr => mgr.CreateMountPointAsync(diskVolume, expectedMountPoint, It.IsAny<CancellationToken>()));
                 }
             }
@@ -159,9 +149,7 @@ namespace VirtualClient.Dependencies
 
                 foreach (DiskVolume diskVolume in this.diskVolumes)
                 {
-                    string expectedMountDirectory = this.mockFixture.StandardizePath(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
-                    string expectedMountPoint = this.mockFixture.Combine(expectedMountDirectory, diskVolume.GetDefaultMountPointName(prefix: "mnt_test"));
-
+                    string expectedMountPoint = this.mockFixture.Combine(diskVolume.DevicePath, diskVolume.GetDefaultMountPointName(prefix: "mnt_test"));
                     this.mockFixture.DiskManager.Verify(mgr => mgr.CreateMountPointAsync(diskVolume, expectedMountPoint, It.IsAny<CancellationToken>()));
                 }
             }

--- a/src/VirtualClient/VirtualClient.Dependencies.UnitTests/MySqlServer/MySQLServerConfigurationTests.cs
+++ b/src/VirtualClient/VirtualClient.Dependencies.UnitTests/MySqlServer/MySQLServerConfigurationTests.cs
@@ -58,7 +58,7 @@ namespace VirtualClient.Dependencies.MySqlServer
 
             string[] expectedCommands =
             {
-                $"python3 {this.packagePath}/configure.py --serverIp 1.2.3.4 --innoDbDirs \"/home/user/mnt_dev_sdc1;/home/user/mnt_dev_sdd1;/home/user/mnt_dev_sde1;\"",
+                $"python3 {this.packagePath}/configure.py --serverIp 1.2.3.4 --innoDbDirs \"/home/user/mnt_dev_sdc1/mysql;/home/user/mnt_dev_sdd1/mysql;/home/user/mnt_dev_sde1/mysql;\"",
             };
 
             int commandNumber = 0;
@@ -115,7 +115,7 @@ namespace VirtualClient.Dependencies.MySqlServer
 
             string[] expectedCommands =
             {
-                $"python3 {this.packagePath}/configure.py --serverIp 1.2.3.4 --innoDbDirs \"/home/user/mnt_dev_sdc1;/home/user/mnt_dev_sdd1;/home/user/mnt_dev_sde1;\" " +
+                $"python3 {this.packagePath}/configure.py --serverIp 1.2.3.4 --innoDbDirs \"/home/user/mnt_dev_sdc1/mysql;/home/user/mnt_dev_sdd1/mysql;/home/user/mnt_dev_sde1/mysql;\" " +
                     $"--inMemory 8192",
             };
 
@@ -326,7 +326,7 @@ namespace VirtualClient.Dependencies.MySqlServer
 
             string[] expectedCommands =
             {
-                $"python3 {this.packagePath}/distribute-database.py --dbName mysql-test --directories \"/home/user/mnt_dev_sdc1;/home/user/mnt_dev_sdd1;/home/user/mnt_dev_sde1;\"",
+                $"python3 {this.packagePath}/distribute-database.py --dbName mysql-test --directories \"/home/user/mnt_dev_sdc1/mysql;/home/user/mnt_dev_sdd1/mysql;/home/user/mnt_dev_sde1/mysql;\"",
             };
 
             int commandNumber = 0;

--- a/src/VirtualClient/VirtualClient.Dependencies.UnitTests/PostgreSQLServer/PostgreSQLServerConfigurationTests.cs
+++ b/src/VirtualClient/VirtualClient.Dependencies.UnitTests/PostgreSQLServer/PostgreSQLServerConfigurationTests.cs
@@ -185,12 +185,16 @@ namespace VirtualClient.Dependencies
 
             if (platform == PlatformID.Unix)
             {
-                expectedCommand = $"python3 {this.packagePath}/distribute-database.py --dbName hammerdbtest --directories \"/home/user/mnt_dev_sdc1;/home/user/mnt_dev_sdd1;/home/user/mnt_dev_sde1;\" --password [A-Za-z0-9+/=]+";
+                expectedCommand = 
+                    $"python3 {this.packagePath}/distribute-database.py " +
+                    $"--dbName hammerdbtest " +
+                    $"--directories \"/home/user/mnt_dev_sdc1/postgresql;/home/user/mnt_dev_sdd1/postgresql;/home/user/mnt_dev_sde1/postgresql;\" " +
+                    $"--password [A-Za-z0-9+/=]+";
             }
             else
             {
                 string tempPackagePath = this.packagePath.Replace(@"\", @"\\");
-                expectedCommand = $"python3 {tempPackagePath}/distribute-database.py --dbName hammerdbtest --directories \"D:\\\\;E:\\\\;F:\\\\;\" --password [A-Za-z0-9+/=]+";
+                expectedCommand = $"python3 {tempPackagePath}/distribute-database.py --dbName hammerdbtest --directories \"D:\\\\postgresql;E:\\\\postgresql;F:\\\\postgresql;\" --password [A-Za-z0-9+/=]+";
             }
 
             this.mockFixture.ProcessManager.OnCreateProcess = (exe, arguments, workingDir) =>

--- a/src/VirtualClient/VirtualClient.Dependencies/MySqlServer/MySqlServerConfiguration.cs
+++ b/src/VirtualClient/VirtualClient.Dependencies/MySqlServer/MySqlServerConfiguration.cs
@@ -302,7 +302,7 @@ namespace VirtualClient.Dependencies.MySqlServer
 
                 foreach (Disk disk in disksToTest)
                 {
-                    diskPaths += $"{disk.GetPreferredAccessPath(this.Platform)};";
+                    diskPaths += $"{this.Combine(disk.GetPreferredAccessPath(this.Platform), "mysql")};";
                 }
             }
 

--- a/src/VirtualClient/VirtualClient.Dependencies/PostgreSQLServer/PostgreSQLServerConfiguration.cs
+++ b/src/VirtualClient/VirtualClient.Dependencies/PostgreSQLServer/PostgreSQLServerConfiguration.cs
@@ -267,7 +267,7 @@ namespace VirtualClient.Dependencies
 
                 foreach (Disk disk in disksToTest)
                 {
-                    diskPaths += $"{disk.GetPreferredAccessPath(this.Platform)};";
+                    diskPaths += $"{this.Combine(disk.GetPreferredAccessPath(this.Platform), "postgresql")};";
                 }
             }
 

--- a/src/VirtualClient/VirtualClient.Main/CommandBase.cs
+++ b/src/VirtualClient/VirtualClient.Main/CommandBase.cs
@@ -503,7 +503,7 @@ namespace VirtualClient
 
             if (this.Verbose)
             {
-                this.LoggingLevel = LogLevel.Debug;
+                this.LoggingLevel = LogLevel.Trace;
             }
             else if (this.LoggingLevel == null)
             {

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-MYSQL-SYSBENCH-OLTP.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-MYSQL-SYSBENCH-OLTP.json
@@ -161,7 +161,6 @@
             "Type": "MountDisks",
             "Parameters": {
                 "Scenario": "CreateMountPoints",
-                "MountLocation": "Root",
                 "Role": "Server"
             }
         },
@@ -170,7 +169,7 @@
             "Parameters": {
                 "Scenario": "DownloadMySqlServerPackage",
                 "BlobContainer": "packages",
-                "BlobName": "mysql-server-8.0.36-v2.zip",
+                "BlobName": "mysql.8.0.36.rev3.zip",
                 "PackageName": "mysql-server",
                 "Extract": true,
                 "Role": "Server"

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-MYSQL-SYSBENCH-TPCC.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-MYSQL-SYSBENCH-TPCC.json
@@ -48,7 +48,6 @@
             "Type": "MountDisks",
             "Parameters": {
                 "Scenario": "CreateMountPoints",
-                "MountLocation": "Root",
                 "Role": "Server"
             }
         },
@@ -57,7 +56,7 @@
             "Parameters": {
                 "Scenario": "DownloadMySqlServerPackage",
                 "BlobContainer": "packages",
-                "BlobName": "mysql-server-8.0.36.zip",
+                "BlobName": "mysql.8.0.36.rev3.zip",
                 "PackageName": "mysql-server",
                 "Extract": true,
                 "Role": "Server"

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-POSTGRESQL-HAMMERDB-TPCC.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-POSTGRESQL-HAMMERDB-TPCC.json
@@ -71,7 +71,7 @@
             "Parameters": {
                 "Scenario": "DownloadPostgreSQLPackage",
                 "BlobContainer": "packages",
-                "BlobName": "postgresql.14.0.0.rev2.zip",
+                "BlobName": "postgresql.14.0.0.rev3.zip",
                 "PackageName": "postgresql",
                 "Extract": true
             }
@@ -114,8 +114,8 @@
                 "Workload": "tpcc",
                 "SQLServer": "postgresql",
                 "PackageName": "hammerdb",
-                "VirtualUsers": "1",
-                "WarehouseCount": "1",
+                "VirtualUsers": 1,
+                "WarehouseCount": 1,
                 "Port": "$.Parameters.Port",
                 "Role": "Server"
             }

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-POSTGRESQL-SYSBENCH-OLTP.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-POSTGRESQL-SYSBENCH-OLTP.json
@@ -162,7 +162,6 @@
             "Type": "MountDisks",
             "Parameters": {
                 "Scenario": "CreateMountPoints",
-                "MountLocation": "Root",
                 "Role": "Server"
             }
         },
@@ -171,7 +170,7 @@
             "Parameters": {
                 "Scenario": "DownloadPostgreSQLServerPackage",
                 "BlobContainer": "packages",
-                "BlobName": "postgresql.14.0.0.rev2.zip",
+                "BlobName": "postgresql.14.0.0.rev3.zip",
                 "PackageName": "postgresql",
                 "Extract": true,
                 "Role": "Server"

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-POSTGRESQL-SYSBENCH-TPCC.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-POSTGRESQL-SYSBENCH-TPCC.json
@@ -50,7 +50,6 @@
             "Type": "MountDisks",
             "Parameters": {
                 "Scenario": "CreateMountPoints",
-                "MountLocation": "Root",
                 "Role": "Server"
             }
         },
@@ -59,7 +58,7 @@
             "Parameters": {
                 "Scenario": "DownloadPostgreSQLServerPackage",
                 "BlobContainer": "packages",
-                "BlobName": "postgresql.14.0.0.rev2.zip",
+                "BlobName": "postgresql.14.0.0.rev3.zip",
                 "PackageName": "postgresql",
                 "Extract": true,
                 "Role": "Server"

--- a/website/docs/workloads/diskspd/diskspd-profiles.md
+++ b/website/docs/workloads/diskspd/diskspd-profiles.md
@@ -2,7 +2,7 @@
 The following profiles run customer-representative or benchmarking scenarios using the DiskSpd workload.  
 
 * [Workload Details](./diskspd.md)  
-* [Testing Specific Disks](../../guides/0220-usage-testing-disks.md)
+* [Testing Disks](../../guides/0220-usage-testing-disks.md)
 
 ## PERF-IO-DISKSPD.json
 Runs an high stress IO-intensive workload using the DiskSpd toolset to test performance of disks on the system. This profile is a Windows-only profile. 
@@ -51,7 +51,7 @@ aspects of the workload execution.
 * **Dependencies**  
   The dependencies defined in the 'Dependencies' section of the profile itself are required in order to run the workload operations effectively.
   * Internet connection.
-  * Any 'DiskFilter' parameter value used should match the set of disks desired. See the link for 'Testing Specific Disks' above.
+  * Any 'DiskFilter' parameter value used should match the set of disks desired. See the link for 'Testing Disks' above.
 
   Additional information on components that exist within the 'Dependencies' section of the profile can be found in the following locations:
   * [Installing Dependencies](https://microsoft.github.io/VirtualClient/docs/category/dependencies/)
@@ -89,7 +89,7 @@ aspects of the workload execution.
 
   | Parameter                 | Purpose                                                                         | Default Value |
   |---------------------------|---------------------------------------------------------------------------------|---------------|
-  | DiskFilter                | Optional. Filter allowing the user to select the disks on which to test.<br/><br/>See the link 'Testing Specific Disks' at the top for more details. | BiggestSize |
+  | DiskFilter                | Optional. Filter allowing the user to select the disks on which to test.<br/><br/>See the link 'Testing Disks' at the top for more details. | BiggestSize |
   | DiskFillSize              | Optional. Allows the user to override the default disk fill size used in the FIO profile (e.g. 500GB -> 26GB). This enables the profile to be used in scenarios where the disk size is very small (e.g. local/temp disk -> 32GB in size). | 500GB |
   | Duration                  | Optional. Defines the amount of time to run each FIO scenario/action within the profile. | 5 minutes |
   | FileSize                  | Optional. Allows the user to override the default file size used in the FIO profile (e.g. 496GB -> 26GB). This enables the profile to be used in scenarios where the disk size is very small (e.g. local/temp disk -> 32GB in size). | 496GB |
@@ -105,7 +105,7 @@ aspects of the workload execution.
   | Scenario                  | Scenario use to define the given action of profile. This can be used to specify exact actions to run or exclude from the profile.  | Any string |
   | MetricsScenario           | The name to use as the "scenario" for all metrics output for the particular profile action. | |
   | CommandLine               | The command line parameters for FIO tool set. |     Any Valid FIO arguments            |
-  | DiskFilter                | Filter allowing the user to select the disks on which to test. | See the link 'Testing Specific Disks' at the top for more details. |
+  | DiskFilter                | Filter allowing the user to select the disks on which to test. | See the link 'Testing Disks' at the top for more details. |
   | Duration                  | Defines the amount of time to run each FIO scenario/action within the profile. | integer or time span |
   | PackageName               | The logical name for FIO package downloaded and that contains the toolset. | |
   | ProcessModel              | Defines how the FIO processes will be executed. | <b>SingleProcess</b><br/>Executes a single FIO process running 1 job targeting I/O operations against each disk. Results are separated per-disk.<br/><br/><b>SingleProcessPerDisk</b><br/>Executes a single FIO process for each disk with each process running 1 job targeting I/O operations against that disk (higher stress profile). Results are separated per-disk.<br/><br/><b>SingleProcessAggregated</b><br/>Executes a single FIO process running 1 job per disk targeting I/O operations against that disk. Results are provided as an aggregation across all disks (i.e. a rollup). |
@@ -119,7 +119,7 @@ aspects of the workload execution.
   number of system cores. 
 
 * **Usage Examples**  
-  The following section provides a few basic examples of how to use the workload profile. See the documentation at the top on 'Testing Specific Disks'
+  The following section provides a few basic examples of how to use the workload profile. See the documentation at the top on 'Testing Disks'
   for information on how to target select disks on the system.
 
   ``` bash

--- a/website/docs/workloads/fio/fio-profiles.md
+++ b/website/docs/workloads/fio/fio-profiles.md
@@ -2,7 +2,7 @@
 The following profiles run customer-representative or benchmarking scenarios using the Flexible I/O Tester (FIO) workload.  
 
 * [Workload Details](./fio.md)  
-* [Testing Specific Disks](../../guides/0220-usage-testing-disks.md)
+* [Testing Disks](../../guides/0220-usage-testing-disks.md)
 
 ## PERF-IO-FIO.json
 Runs an IO-intensive workload using the Flexible IO Tester (FIO) toolset to test performance of disks on the system. Although this profile
@@ -53,7 +53,8 @@ aspects of the workload execution.
 * **Dependencies**  
   The dependencies defined in the 'Dependencies' section of the profile itself are required in order to run the workload operations effectively.
   * Internet connection.
-  * Any 'DiskFilter' parameter value used should match the set of disks desired. See the link for 'Testing Specific Disks' above.
+  * Disk mount points exist for the disks to be targeted. Virtual Client will generally ensure that mount points exist by default. Details for mount point creation procedures can be found in the 'Testing Disks' documentation above.
+  * Any 'DiskFilter' parameter value used should match the set of disks desired. See the link for 'Testing Disks' above.
 
   Additional information on components that exist within the 'Dependencies' section of the profile can be found in the following locations:
   * [Installing Dependencies](https://microsoft.github.io/VirtualClient/docs/category/dependencies/)
@@ -100,7 +101,7 @@ aspects of the workload execution.
   | Parameter                 | Purpose                                                                         | Default Value |
   |---------------------------|---------------------------------------------------------------------------------|---------------|
   | DataIntegrityFileSize     | Optional. Defines the size of the file/disk space that will be used for profile disk integrity scenarios/actions. | 4GB |
-  | DiskFilter                | Optional. Filter allowing the user to select the disks on which to test.<br/><br/>See the link 'Testing Specific Disks' at the top for more details. | BiggestSize |
+  | DiskFilter                | Optional. Filter allowing the user to select the disks on which to test.<br/><br/>See the link 'Testing Disks' at the top for more details. | BiggestSize |
   | DiskFillSize              | Optional. Allows the user to override the default disk fill size used in the FIO profile (e.g. 500GB -> 26GB). This enables the profile to be used in scenarios where the disk size is very small (e.g. local/temp disk -> 32GB in size). | 500GB |
   | Duration                  | Optional. Defines the amount of time to run each FIO scenario/action within the profile. | 5 minutes |
   | Engine                    | Optional. Defines the I/O engine to use for the FIO operations (e.g. posixaio, libaio, windowsaio). | Linux = libaio, Windows = windowsaio |
@@ -117,7 +118,7 @@ aspects of the workload execution.
   | Scenario                  | Scenario use to define the given action of profile. This can be used to specify exact actions to run or exclude from the profile.  | Any string |
   | MetricsScenario           | The name to use as the "scenario" for all metrics output for the particular profile action. | |
   | CommandLine               | The command line parameters for FIO tool set. |     Any Valid FIO arguments            |
-  | DiskFilter                | Filter allowing the user to select the disks on which to test. | See the link 'Testing Specific Disks' at the top for more details. |
+  | DiskFilter                | Filter allowing the user to select the disks on which to test. | See the link 'Testing Disks' at the top for more details. |
   | Duration                  | Defines the amount of time to run each FIO scenario/action within the profile. | integer or time span |
   | Engine                    | Optional. Defines the I/O engine to use for the FIO operations (e.g. posixaio, libaio, windowsaio). | Linux = libaio, Windows = windowsaio |
   | PackageName               | The logical name for FIO package downloaded and that contains the toolset. | |
@@ -132,7 +133,7 @@ aspects of the workload execution.
   number of system cores. 
 
 * **Usage Examples**  
-  The following section provides a few basic examples of how to use the workload profile. See the documentation at the top on 'Testing Specific Disks'
+  The following section provides a few basic examples of how to use the workload profile. See the documentation at the top on 'Testing Disks'
   for information on how to target select disks on the system.
 
   ``` bash
@@ -202,7 +203,8 @@ This profile uses an algorithm to determine the total number of jobs/threads as 
 * **Dependencies**  
   The dependencies defined in the 'Dependencies' section of the profile itself are required in order to run the workload operations effectively.
   * Internet connection.
-  * Any 'DiskFilter' parameter value used should match the set of disks desired. See the link for 'Testing Specific Disks' above.
+  * Disk mount points exist for the disks to be targeted. Virtual Client will generally ensure that mount points exist by default. Details for mount point creation procedures can be found in the 'Testing Disks' documentation above.
+  * Any 'DiskFilter' parameter value used should match the set of disks desired. See the link for 'Testing Disks' above.
 
   Additional information on components that exist within the 'Dependencies' section of the profile can be found in the following locations:
   * [Installing Dependencies](https://microsoft.github.io/VirtualClient/docs/category/dependencies/)
@@ -376,7 +378,8 @@ This profile uses an algorithm to determine the amount of IOPS to run against th
 * **Dependencies**  
   The dependencies defined in the 'Dependencies' section of the profile itself are required in order to run the workload operations effectively.
   * Internet connection.
-  * Any 'DiskFilter' parameter value used should match the set of disks desired. See the link for 'Testing Specific Disks' above.
+  * Disk mount points exist for the disks to be targeted. Virtual Client will generally ensure that mount points exist by default. Details for mount point creation procedures can be found in the 'Testing Disks' documentation above.
+  * Any 'DiskFilter' parameter value used should match the set of disks desired. See the link for 'Testing Disks' above.
 
   Additional information on components that exist within the 'Dependencies' section of the profile can be found in the following locations:
   * [Installing Dependencies](https://microsoft.github.io/VirtualClient/docs/category/dependencies/)
@@ -507,7 +510,8 @@ Therefore, they are performed on different disks
 * **Dependencies**  
   The dependencies defined in the 'Dependencies' section of the profile itself are required in order to run the workload operations effectively.
   * Internet connection.
-  * Any 'DiskFilter' parameter value used should match the set of disks desired. See the link for 'Testing Specific Disks' above.
+  * Disk mount points exist for the disks to be targeted. Virtual Client will generally ensure that mount points exist by default. Details for mount point creation procedures can be found in the 'Testing Disks' documentation above.
+  * Any 'DiskFilter' parameter value used should match the set of disks desired. See the link for 'Testing Disks' above.
 
   Additional information on components that exist within the 'Dependencies' section of the profile can be found in the following locations:
   * [Installing Dependencies](https://microsoft.github.io/VirtualClient/docs/category/dependencies/)


### PR DESCRIPTION
- Set full permissions on the root directory for each mount point (e.g. chmod 777, chown).
- Update PostgreSQL database configuration and distribution logic to use a "subdirectory" within the mount point directory. PostgreSQL requires the "postgresql" user to have ownership of the directory in which database/tablespace files exist. We DO NOT want these permissions applied to the root mount point directory as it would impact all other workloads trying to access the file system through the mount point.
- Update MySQL database configuration and distribution logic to use a "subdirectory" within the mount point directory. Same reason as for PostgreSQL for the "mysql" user ownership dilemma.