### PR TITLE
Added logic to copy contentPathTemplate in copyConstructor of VirtualClientComponent

### DIFF
--- a/src/VirtualClient/VirtualClient.Contracts/VirtualClientComponent.cs
+++ b/src/VirtualClient/VirtualClient.Contracts/VirtualClientComponent.cs
@@ -61,6 +61,7 @@ namespace VirtualClient.Contracts
             this.FailFast = component.FailFast;
             this.LogToFile = component.LogToFile;
             this.MetadataContract = component.MetadataContract;
+            this.ContentPathTemplate = component.ContentPathTemplate;
 
             if (component.Metadata?.Any() == true)
             {


### PR DESCRIPTION
The `NetworkWorkloadExecutor` uses the copy constructor to create the `NttcpExecutor`, but this constructor doesn't copy the `ContentPathTemplate`. As a result, the child executor has it set to null, which leads to a fallback to the `defaultPathTemplate`. This caused the logs for the `NTTTcpExecutor` to be created in a different folder.

Added the images below with and without changes around how the `contentpathtemplate` is passed to the child components created using copy constructor. 

<img width="1687" height="1200" alt="image (4)" src="https://github.com/user-attachments/assets/e0fbf10d-621d-4092-b7b0-6e99b670662c" />
<img width="1670" height="1024" alt="image (3)" src="https://github.com/user-attachments/assets/a1db1675-fbce-486f-a362-ee44cc24c30b" />
