### PR TITLE
Fix ThrowOnUsageError false positive on parameter values containing d…

### DIFF
--- a/src/VirtualClient/VirtualClient.Main/CommandLineExtensions.cs
+++ b/src/VirtualClient/VirtualClient.Main/CommandLineExtensions.cs
@@ -95,11 +95,14 @@ namespace VirtualClient
                     }
 
                     // Scenario 3:
-                    // There are no options on the command line that are not valid for the command.
+                    // There are options on the command line that are not valid for the command.
+                    // Use a full-string match (anchored regex) to avoid false positives from
+                    // values bound to recognized options that contain double-dash prefixed
+                    // substrings (e.g. --parameters="...DriverInstallationCommandArguments=--silent...").
                     IEnumerable<Token> arguments = parseResults.Tokens.Where(t => t.Type == TokenType.Argument);
                     if (arguments?.Any() == true)
                     {
-                        Regex optionMatchExpression = new Regex("--[a-z]+", RegexOptions.IgnoreCase);
+                        Regex optionMatchExpression = new Regex(@"^--[a-z][-a-z]*$", RegexOptions.IgnoreCase);
                         foreach (Token argument in arguments)
                         {
                             if (optionMatchExpression.IsMatch(argument.Value?.Trim()))

--- a/src/VirtualClient/VirtualClient.UnitTests/CommandLineOptionTests.cs
+++ b/src/VirtualClient/VirtualClient.UnitTests/CommandLineOptionTests.cs
@@ -153,6 +153,7 @@ namespace VirtualClient
         [TestCase("--ps", "https://anystorageaccount.blob.core.windows.net/?sv=2020-08-04&ss=b")]
         [TestCase("--parameters", "Param1=Value1,,,Param2=Value2")]
         [TestCase("--pm", "Param1=Value1,,,Param2=Value2")]
+        [TestCase("--parameters", "DriverInstallationCommandArguments=--silent,,,UserName=HpcUser,,,DriverBlobName=nvidiagriddriver-v20.0.zip")]
         [TestCase("--seed", "1234")]
         [TestCase("--sd", "1234")]
         [TestCase("--scenarios", "Scenario1")]


### PR DESCRIPTION
…ouble-dash prefixes

The Scenario 3 regex used IsMatch with an unanchored pattern (--[a-z]+), causing substring matches on values like DriverInstallationCommandArguments=--silent inside --parameters. Changed to a full-string anchored regex (^--[a-z][-a-z]*$) so only standalone option-like tokens are flagged as unsupported.