### PR TITLE
Add support for defining a proxy to use for Event Hub communications routing

### DIFF
--- a/src/VirtualClient/VirtualClient.Contracts/Constants.cs
+++ b/src/VirtualClient/VirtualClient.Contracts/Constants.cs
@@ -171,9 +171,19 @@ namespace VirtualClient.Contracts
         public const string USERPROFILE = nameof(USERPROFILE);
 
         /// <summary>
-        /// Name = VC_PASSWORD
+        /// Name = VC_EVENT_HUB_PROXY
         /// </summary>
-        public const string VC_PASSWORD = nameof(VC_PASSWORD);
+        public const string VC_EVENT_HUB_PROXY = nameof(VC_EVENT_HUB_PROXY);
+
+        /// <summary>
+        /// Name = VC_EVENT_HUB_PROXY_USERNAME
+        /// </summary>
+        public const string VC_EVENT_HUB_PROXY_USERNAME = nameof(VC_EVENT_HUB_PROXY_USERNAME);
+
+        /// <summary>
+        /// Name = VC_EVENT_HUB_PROXY_PASSWORD
+        /// </summary>
+        public const string VC_EVENT_HUB_PROXY_PASSWORD = nameof(VC_EVENT_HUB_PROXY_PASSWORD);
 
         /// <summary>
         /// Name = VC_LOGS_DIR
@@ -189,6 +199,11 @@ namespace VirtualClient.Contracts
         /// Name = VC_PACKAGES_DIR
         /// </summary>
         public const string VC_PACKAGES_DIR = nameof(VC_PACKAGES_DIR);
+
+        /// <summary>
+        /// Name = VC_PASSWORD
+        /// </summary>
+        public const string VC_PASSWORD = nameof(VC_PASSWORD);
 
         /// <summary>
         /// Name = VC_STATE_DIR

--- a/src/VirtualClient/VirtualClient.Core/DependencyFactory.cs
+++ b/src/VirtualClient/VirtualClient.Core/DependencyFactory.cs
@@ -10,7 +10,6 @@ namespace VirtualClient
     using System.Linq;
     using System.Net;
     using System.Security.Cryptography.X509Certificates;
-    using System.Threading.Tasks;
     using Azure.Core;
     using Azure.Messaging.EventHubs.Producer;
     using Microsoft.Extensions.Logging;
@@ -136,16 +135,18 @@ namespace VirtualClient
         /// <param name="eventHubName">The name of the Event Hub within the namespace (e.g. telemetry-logs, telemetry-metrics).</param>
         /// <param name="eventHubNameSpace">Event hub namespace</param>
         /// <param name="tokenCredential">Azure Token credential to authenticate with </param>
-        public static EventHubTelemetryChannel CreateEventHubTelemetryChannel(string eventHubName, string eventHubNameSpace = null, TokenCredential tokenCredential = null, string eventHubConnectionString = null)
+        /// <param name="clientOptions">Options for configuring the Event Hub producer client. For example, these can be used to support the use of a proxy.</param>
+        public static EventHubTelemetryChannel CreateEventHubTelemetryChannel(string eventHubName, string eventHubNameSpace = null, TokenCredential tokenCredential = null, string eventHubConnectionString = null, EventHubProducerClientOptions clientOptions = null)
         {
             EventHubProducerClient client;
+
             if (!string.IsNullOrEmpty(eventHubConnectionString))
             {
-                client = new EventHubProducerClient(eventHubConnectionString, eventHubName);
+                client = new EventHubProducerClient(eventHubConnectionString, eventHubName, clientOptions);
             }
             else
             {
-                client = new EventHubProducerClient(eventHubNameSpace, eventHubName, tokenCredential);
+                client = new EventHubProducerClient(eventHubNameSpace, eventHubName, tokenCredential, clientOptions);
             }
 
             EventHubTelemetryChannel channel = new EventHubTelemetryChannel(client, enableDiagnostics: true);
@@ -160,7 +161,8 @@ namespace VirtualClient
         /// <param name="settings">Defines the settings for each individual Event Hub targeted.</param>
         /// <param name="level">The logging severity level.</param>
         /// <param name="flushTimeout">A timeout to apply to flush operations.</param>
-        public static IEnumerable<ILoggerProvider> CreateEventHubLoggerProviders(DependencyEventHubStore eventHubStore, EventHubLogSettings settings, LogLevel level, TimeSpan? flushTimeout = null)
+        /// <param name="clientOptions">Options for configuring the Event Hub producer client. For example, these can be used to support the use of a proxy.</param>
+        public static IEnumerable<ILoggerProvider> CreateEventHubLoggerProviders(DependencyEventHubStore eventHubStore, EventHubLogSettings settings, LogLevel level, TimeSpan? flushTimeout = null, EventHubProducerClientOptions clientOptions = null)
         {
             List<ILoggerProvider> loggerProviders = new List<ILoggerProvider>();
 
@@ -189,7 +191,8 @@ namespace VirtualClient
                         eventHubName: settings.TracesHubName,
                         eventHubNameSpace: authenticationContext.EventHubNamespace,
                         authenticationContext.TokenCredential,
-                        authenticationContext.ConnectionString);
+                        authenticationContext.ConnectionString,
+                        clientOptions);
 
                     tracesChannel.EventTransmissionError += (sender, args) =>
                     {
@@ -207,7 +210,8 @@ namespace VirtualClient
                         eventHubName: settings.MetricsHubName,
                         eventHubNameSpace: authenticationContext.EventHubNamespace,
                         authenticationContext.TokenCredential,
-                        authenticationContext.ConnectionString);
+                        authenticationContext.ConnectionString,
+                        clientOptions);
 
                     metricsChannel.EventTransmissionError += (sender, args) =>
                     {
@@ -226,7 +230,8 @@ namespace VirtualClient
                         eventHubName: settings.EventsHubName,
                         eventHubNameSpace: authenticationContext.EventHubNamespace,
                         authenticationContext.TokenCredential,
-                        authenticationContext.ConnectionString);
+                        authenticationContext.ConnectionString,
+                        clientOptions);
 
                     systemEventsChannel.EventTransmissionError += (sender, args) =>
                     {

--- a/src/VirtualClient/VirtualClient.Main/CommandBase.cs
+++ b/src/VirtualClient/VirtualClient.Main/CommandBase.cs
@@ -11,12 +11,14 @@ namespace VirtualClient
     using System.IO;
     using System.IO.Abstractions;
     using System.Linq;
+    using System.Net;
     using System.Reflection;
     using System.Runtime.InteropServices;
     using System.Security.Cryptography.X509Certificates;
     using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
+    using Azure.Messaging.EventHubs.Producer;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
@@ -945,7 +947,28 @@ namespace VirtualClient
 
                     case "eventhub":
                         DependencyEventHubStore store = EndpointUtility.CreateEventHubStoreReference(DependencyStore.Telemetry, endpoint: loggerParameters, this.CertificateManager ?? new CertificateManager());
-                        CommandBase.AddEventHubLogging(loggingProviders, configuration, store, loggingLevel);
+
+                        // Supports the use of a Proxy for routing Event Hub traffic. This allows clients to use secure endpoints inside of their network 
+                        // to route traffic to the Event Hub namespace (vs. a direct connection).
+                        // (e.g. http://proxy-dmz.contoso.com:135).
+                        EventHubProducerClientOptions clientOptions = new EventHubProducerClientOptions();
+                        string proxyUri = platformSpecifics.GetEnvironmentVariable(EnvironmentVariable.VC_EVENT_HUB_PROXY);
+
+                        if (!string.IsNullOrWhiteSpace(proxyUri))
+                        {
+                            clientOptions.ConnectionOptions.TransportType = Azure.Messaging.EventHubs.EventHubsTransportType.AmqpWebSockets;
+                            clientOptions.ConnectionOptions.Proxy = new System.Net.WebProxy(new Uri(proxyUri), true);
+
+                            string proxyUsername = platformSpecifics.GetEnvironmentVariable(EnvironmentVariable.VC_EVENT_HUB_PROXY_USERNAME);
+                            string proxyPassword = platformSpecifics.GetEnvironmentVariable(EnvironmentVariable.VC_EVENT_HUB_PROXY_PASSWORD);
+
+                            if (!string.IsNullOrWhiteSpace(proxyUsername) && !string.IsNullOrWhiteSpace(proxyPassword))
+                            {
+                                clientOptions.ConnectionOptions.Proxy.Credentials = new NetworkCredential(proxyUsername, proxyPassword);
+                            }
+                        }
+
+                        CommandBase.AddEventHubLogging(loggingProviders, configuration, store, loggingLevel, clientOptions);
                         break;
 
                     case "proxy":
@@ -1090,7 +1113,7 @@ namespace VirtualClient
             }
         }
 
-        private static void AddEventHubLogging(List<ILoggerProvider> loggingProviders, IConfiguration configuration, DependencyEventHubStore eventHubStore, LogLevel level)
+        private static void AddEventHubLogging(List<ILoggerProvider> loggingProviders, IConfiguration configuration, DependencyEventHubStore eventHubStore, LogLevel level, EventHubProducerClientOptions clientOptions = null)
         {
             if (eventHubStore != null)
             {
@@ -1098,7 +1121,7 @@ namespace VirtualClient
 
                 if (settings.IsEnabled)
                 {
-                    IEnumerable<ILoggerProvider> eventHubProviders = DependencyFactory.CreateEventHubLoggerProviders(eventHubStore, settings, level);
+                    IEnumerable<ILoggerProvider> eventHubProviders = DependencyFactory.CreateEventHubLoggerProviders(eventHubStore, settings, level, clientOptions: clientOptions);
                     if (eventHubProviders?.Any() == true)
                     {
                         loggingProviders.AddRange(eventHubProviders);

--- a/website/docs/guides/0610-integration-event-hub.md
+++ b/website/docs/guides/0610-integration-event-hub.md
@@ -239,6 +239,17 @@ The following documentation illustrates how to use connection string-style refer
     --event-hub="Endpoint=sb://aaa.servicebus.windows.net/;SharedAccessKeyName=TelemetrySharedAccessKey;SharedAccessKey=bbbbbbbbbb..."
     ```
 
+### Proxy Support
+Virtual Client supports using a proxy to relay Event Hub communications. The application will use a simple web proxy model passing the AMQP protocol traffic to the proxy
+using simple HTTP/web sockets communications. The proxy supports anonymous authentication as well as basic authentication (i.e. username and password). Set the following
+environment variables to enable support for proxy communications:
+
+| Environment Variable        | Description |
+|-----------------------------|-------------|
+| VC_EVENT_HUB_PROXY          | The host name or IP address of the proxy server to use for Event Hub communications routing. |
+| VC_EVENT_HUB_PROXY_USERNAME | The username to use for basic authentication with the proxy endpoint. If not defined, anonymous authentication will be used. |
+| VC_EVENT_HUB_PROXY_PASSWORD | The password to use for basic authentication with the proxy endpoint. If not defined, anonymous authentication will be used. |
+
 ### Create Event Hub Namespace
 The Virtual Client emits data for each one of these categories into a distinct/singular target Event Hub within an Event Hub namespace (a 1-to-1 mapping).
 In order to use Event Hub with the Virtual Client, an Event Hub namespace must be setup. The following recommendations relate to the Event Hub namespace itself.


### PR DESCRIPTION
We have an external partner team that is making changes to VC and specially compiling the application in order to add support for a proxy when sending Event Hub traffic. We need to ensure the team is using specific builds of VC and thus need to support their proxy use case.