### PR TITLE
Separating speccpu benchmarks by action/scenario

### DIFF
--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-FPRATE.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-FPRATE.json
@@ -10,7 +10,7 @@
         "RecommendedMinimumExecutionTime": "(4-cores)=02:00:00,(16-cores)=05:00:00,(64-cores)=10:00:00",
         "SupportedPlatforms": "linux-x64,linux-arm64,win-x64,win-arm64",
         "SupportedOperatingSystems": "Azure Linux,CentOS,Debian,RedHat,Suse,Ubuntu,Windows",
-        "Notes": "Using a private package 'speccpu.2017.1.1.9-danielbowers.zip' to enable support for speccpu on Ubuntu 24",
+        "Notes": "Using a private package 'speccpu.2017.1.1.9-danielbowers.zip' to enable support for speccpu on Ubuntu 24. SPEC CPU 2017 was not initially designed for win-arm64.",
         "Limitations": "The following benchmarks don't work on Windows: 507, 511, 521, 526, 527, 538"
     },
     "Parameters": {
@@ -19,7 +19,6 @@
         "RunPeak": false,
         "Threads": "{LogicalCoreCount}",
         "Copies": "{LogicalCoreCount}",
-        "Benchmarks": "{calculate(\"{Platform}\".StartsWith(\"linux\") ? \"fprate\" : \"503 508 510 519 544 549 554\")}",
         "BaseOptimizingFlags": "-g -O3 -march={calculate(\"{Architecture}\" == \"x64\" ? \"native\" : \"armv8-a\")} -frecord-gcc-switches",
         "PeakOptimizingFlags": "-g -Ofast -march={calculate(\"{Architecture}\" == \"x64\" ? \"native\" : \"armv8-a\")} -flto -frecord-gcc-switches"
     },
@@ -27,10 +26,196 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "ExecuteSPECBenchmark",
+                "Scenario": "503",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fprate",
-                "Benchmarks": "$.Parameters.Benchmarks",
+                "Benchmarks": "503",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "507",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fprate",
+                "Benchmarks": "507",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "508",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fprate",
+                "Benchmarks": "508",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "510",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fprate",
+                "Benchmarks": "510",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "511",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fprate",
+                "Benchmarks": "511",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "519",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fprate",
+                "Benchmarks": "519",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "521",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fprate",
+                "Benchmarks": "521",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "526",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fprate",
+                "Benchmarks": "526",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "527",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fprate",
+                "Benchmarks": "527",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "538",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fprate",
+                "Benchmarks": "538",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "544",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fprate",
+                "Benchmarks": "544",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "549",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fprate",
+                "Benchmarks": "549",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "554",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fprate",
+                "Benchmarks": "554",
                 "PackageName": "speccpu2017",
                 "RunPeak": "$.Parameters.RunPeak",
                 "Threads": "$.Parameters.Threads",

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-FPRATE.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-FPRATE.json
@@ -231,7 +231,7 @@
             "Parameters": {
                 "Scenario": "MaskAptDailyTimers",
                 "SupportedPlatforms": "linux-x64,linux-arm64",
-                "Command": "bash -c 'systemctl mask apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; systemctl stop apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; exit 0'"
+                "Command": "bash -c \"systemctl mask apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; systemctl stop apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; exit 0\""
             }
         },
         {

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-FPRATE.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-FPRATE.json
@@ -26,7 +26,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "503",
+                "Scenario": "benchmark_503.bwaves_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fprate",
                 "Benchmarks": "503",
@@ -41,7 +41,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "507",
+                "Scenario": "benchmark_507.cactuBSSN_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fprate",
                 "Benchmarks": "507",
@@ -57,7 +57,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "508",
+                "Scenario": "benchmark_508.namd_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fprate",
                 "Benchmarks": "508",
@@ -72,7 +72,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "510",
+                "Scenario": "benchmark_510.parest_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fprate",
                 "Benchmarks": "510",
@@ -87,7 +87,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "511",
+                "Scenario": "benchmark_511.povray_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fprate",
                 "Benchmarks": "511",
@@ -103,7 +103,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "519",
+                "Scenario": "benchmark_519.lbm_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fprate",
                 "Benchmarks": "519",
@@ -118,7 +118,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "521",
+                "Scenario": "benchmark_521.wrf_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fprate",
                 "Benchmarks": "521",
@@ -134,7 +134,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "526",
+                "Scenario": "benchmark_526.blender_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fprate",
                 "Benchmarks": "526",
@@ -150,7 +150,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "527",
+                "Scenario": "benchmark_527.cam4_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fprate",
                 "Benchmarks": "527",
@@ -166,7 +166,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "538",
+                "Scenario": "benchmark_538.imagick_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fprate",
                 "Benchmarks": "538",
@@ -182,7 +182,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "544",
+                "Scenario": "benchmark_544.nab_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fprate",
                 "Benchmarks": "544",
@@ -197,7 +197,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "549",
+                "Scenario": "benchmark_549.fotonik3d_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fprate",
                 "Benchmarks": "549",
@@ -212,7 +212,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "554",
+                "Scenario": "benchmark_554.roms_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fprate",
                 "Benchmarks": "554",

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-FPSPEED.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-FPSPEED.json
@@ -186,7 +186,7 @@
             "Parameters": {
                 "Scenario": "MaskAptDailyTimers",
                 "SupportedPlatforms": "linux-x64,linux-arm64",
-                "Command": "bash -c 'systemctl mask apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; systemctl stop apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; exit 0'"
+                "Command": "bash -c \"systemctl mask apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; systemctl stop apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; exit 0\""
             }
         },
         {

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-FPSPEED.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-FPSPEED.json
@@ -8,9 +8,9 @@
     },
     "Metadata": {
         "RecommendedMinimumExecutionTime": "(4-cores)=02:00:00,(16-cores)=06:00:00,(64-cores)=12:00:00",
-        "SupportedPlatforms": "linux-x64,linux-arm64,win-x64,win-arm64",
+        "SupportedPlatforms": "linux-x64,linux-arm64,win-x64",
         "SupportedOperatingSystems": "Azure Linux,CentOS,Debian,RedHat,Suse,Ubuntu,Windows",
-        "Notes": "Using a private package 'speccpu.2017.1.1.9-danielbowers.zip' to enable support for speccpu on Ubuntu 24",
+        "Notes": "Using a private package 'speccpu.2017.1.1.9-danielbowers.zip' to enable support for speccpu on Ubuntu 24. SPEC CPU 2017 was not initially designed for win-arm64.",
         "Limitations": "The following benchmarks don't work on Windows: 607, 621, 627, 628, 638, 649"
     },
     "Parameters": {
@@ -19,7 +19,6 @@
         "RunPeak": false,
         "Threads": "{LogicalCoreCount}",
         "Copies": "{LogicalCoreCount}",
-        "Benchmarks": "{calculate(\"{Platform}\".StartsWith(\"linux\") ? \"fpspeed\" : \"603 619 644 654\")}",
         "BaseOptimizingFlags": "-g -O3 -march={calculate(\"{Architecture}\" == \"x64\" ? \"native\" : \"armv8-a\")} -frecord-gcc-switches",
         "PeakOptimizingFlags": "-g -Ofast -march={calculate(\"{Architecture}\" == \"x64\" ? \"native\" : \"armv8-a\")} -flto -frecord-gcc-switches"
     },
@@ -27,10 +26,151 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "ExecuteSPECBenchmark",
+                "Scenario": "603",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fpspeed",
-                "Benchmarks": "$.Parameters.Benchmarks",
+                "Benchmarks": "603",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "607",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fpspeed",
+                "Benchmarks": "607",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "619",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fpspeed",
+                "Benchmarks": "619",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "621",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fpspeed",
+                "Benchmarks": "621",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "627",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fpspeed",
+                "Benchmarks": "627",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "628",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fpspeed",
+                "Benchmarks": "628",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "638",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fpspeed",
+                "Benchmarks": "638",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "644",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fpspeed",
+                "Benchmarks": "644",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "649",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fpspeed",
+                "Benchmarks": "649",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "654",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "fpspeed",
+                "Benchmarks": "654",
                 "PackageName": "speccpu2017",
                 "RunPeak": "$.Parameters.RunPeak",
                 "Threads": "$.Parameters.Threads",

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-FPSPEED.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-FPSPEED.json
@@ -26,7 +26,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "603",
+                "Scenario": "benchmark_603.bwaves_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fpspeed",
                 "Benchmarks": "603",
@@ -41,7 +41,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "607",
+                "Scenario": "benchmark_607.cactuBSSN_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fpspeed",
                 "Benchmarks": "607",
@@ -57,7 +57,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "619",
+                "Scenario": "benchmark_619.lbm_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fpspeed",
                 "Benchmarks": "619",
@@ -72,7 +72,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "621",
+                "Scenario": "benchmark_621.wrf_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fpspeed",
                 "Benchmarks": "621",
@@ -88,7 +88,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "627",
+                "Scenario": "benchmark_627.cam4_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fpspeed",
                 "Benchmarks": "627",
@@ -104,7 +104,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "628",
+                "Scenario": "benchmark_628.pop2_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fpspeed",
                 "Benchmarks": "628",
@@ -120,7 +120,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "638",
+                "Scenario": "benchmark_638.imagick_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fpspeed",
                 "Benchmarks": "638",
@@ -136,7 +136,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "644",
+                "Scenario": "benchmark_644.nab_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fpspeed",
                 "Benchmarks": "644",
@@ -151,7 +151,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "649",
+                "Scenario": "benchmark_649.fotonik3d_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fpspeed",
                 "Benchmarks": "649",
@@ -167,7 +167,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "654",
+                "Scenario": "benchmark_654.roms_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "fpspeed",
                 "Benchmarks": "654",

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-INTRATE.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-INTRATE.json
@@ -26,7 +26,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "500",
+                "Scenario": "benchmark_500.perlbench_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intrate",
                 "Benchmarks": "500",
@@ -42,7 +42,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "502",
+                "Scenario": "benchmark_502.gcc_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intrate",
                 "Benchmarks": "502",
@@ -58,7 +58,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "505",
+                "Scenario": "benchmark_505.mcf_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intrate",
                 "Benchmarks": "505",
@@ -73,7 +73,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "520",
+                "Scenario": "benchmark_520.omnetpp_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intrate",
                 "Benchmarks": "520",
@@ -89,7 +89,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "523",
+                "Scenario": "benchmark_523.xalancbmk_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intrate",
                 "Benchmarks": "523",
@@ -105,7 +105,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "525",
+                "Scenario": "benchmark_525.x264_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intrate",
                 "Benchmarks": "525",
@@ -120,7 +120,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "531",
+                "Scenario": "benchmark_531.deepsjeng_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intrate",
                 "Benchmarks": "531",
@@ -136,7 +136,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "541",
+                "Scenario": "benchmark_541.leela_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intrate",
                 "Benchmarks": "541",
@@ -151,7 +151,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "548",
+                "Scenario": "benchmark_548.exchange2_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intrate",
                 "Benchmarks": "548",
@@ -166,7 +166,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "557",
+                "Scenario": "benchmark_557.xz_r",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intrate",
                 "Benchmarks": "557",

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-INTRATE.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-INTRATE.json
@@ -8,9 +8,9 @@
     },
     "Metadata": {
         "RecommendedMinimumExecutionTime": "(8-cores)=04:00:00,(16-cores)=08:00:00,(64-cores)=10:00:00",
-        "SupportedPlatforms": "linux-x64,linux-arm64,win-x64,win-arm64",
+        "SupportedPlatforms": "linux-x64,linux-arm64,win-x64",
         "SupportedOperatingSystems": "Azure Linux,CentOS,Debian,RedHat,Suse,Ubuntu,Windows",
-        "Notes": "Using a private package 'speccpu.2017.1.1.9-danielbowers.zip' to enable support for speccpu on Ubuntu 24",
+        "Notes": "Using a private package 'speccpu.2017.1.1.9-danielbowers.zip' to enable support for speccpu on Ubuntu 24. SPEC CPU 2017 was not initially designed for win-arm64.",
         "Limitations": "The following benchmarks don't work on Windows: 500, 502, 520, 523, 531"
     },
     "Parameters": {
@@ -19,7 +19,6 @@
         "RunPeak": false,
         "Threads": "{LogicalCoreCount}",
         "Copies": "{LogicalCoreCount}",
-        "Benchmarks": "{calculate(\"{Platform}\".StartsWith(\"linux\") ? \"intrate\" : \"505 525 541 548 557\")}",
         "BaseOptimizingFlags": "-g -O3 -march={calculate(\"{Architecture}\" == \"x64\" ? \"native\" : \"armv8-a\")} -frecord-gcc-switches",
         "PeakOptimizingFlags": "-g -Ofast -march={calculate(\"{Architecture}\" == \"x64\" ? \"native\" : \"armv8-a\")} -flto -frecord-gcc-switches"
     },
@@ -27,10 +26,150 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "ExecuteSPECBenchmark",
+                "Scenario": "500",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intrate",
-                "Benchmarks": "$.Parameters.Benchmarks",
+                "Benchmarks": "500",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "502",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "intrate",
+                "Benchmarks": "502",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "505",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "intrate",
+                "Benchmarks": "505",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "520",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "intrate",
+                "Benchmarks": "520",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "523",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "intrate",
+                "Benchmarks": "523",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "525",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "intrate",
+                "Benchmarks": "525",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "531",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "intrate",
+                "Benchmarks": "531",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "541",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "intrate",
+                "Benchmarks": "541",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "548",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "intrate",
+                "Benchmarks": "548",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "557",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "intrate",
+                "Benchmarks": "557",
                 "PackageName": "speccpu2017",
                 "RunPeak": "$.Parameters.RunPeak",
                 "Threads": "$.Parameters.Threads",

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-INTRATE.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-INTRATE.json
@@ -185,7 +185,7 @@
             "Parameters": {
                 "Scenario": "MaskAptDailyTimers",
                 "SupportedPlatforms": "linux-x64,linux-arm64",
-                "Command": "bash -c 'systemctl mask apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; systemctl stop apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; exit 0'"
+                "Command": "bash -c \"systemctl mask apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; systemctl stop apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; exit 0\""
             }
         },
         {

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-INTSPEED.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-INTSPEED.json
@@ -189,7 +189,7 @@
             "Parameters": {
                 "Scenario": "MaskAptDailyTimers",
                 "SupportedPlatforms": "linux-x64,linux-arm64",
-                "Command": "bash -c 'systemctl mask apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; systemctl stop apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; exit 0'"
+                "Command": "bash -c \"systemctl mask apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; systemctl stop apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; exit 0\""
             }
         },
         {

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-INTSPEED.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-INTSPEED.json
@@ -26,7 +26,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "600",
+                "Scenario": "benchmark_600.perlbench_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intspeed",
                 "Benchmarks": "600",
@@ -42,7 +42,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "602",
+                "Scenario": "benchmark_602.gcc_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intspeed",
                 "Benchmarks": "602",
@@ -58,7 +58,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "605",
+                "Scenario": "benchmark_605.mcf_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intspeed",
                 "Benchmarks": "605",
@@ -74,7 +74,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "620",
+                "Scenario": "benchmark_620.omnetpp_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intspeed",
                 "Benchmarks": "620",
@@ -90,7 +90,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "623",
+                "Scenario": "benchmark_623.xalancbmk_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intspeed",
                 "Benchmarks": "623",
@@ -106,7 +106,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "625",
+                "Scenario": "benchmark_625.x264_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intspeed",
                 "Benchmarks": "625",
@@ -122,7 +122,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "631",
+                "Scenario": "benchmark_631.deepsjeng_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intspeed",
                 "Benchmarks": "631",
@@ -138,7 +138,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "641",
+                "Scenario": "benchmark_641.leela_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intspeed",
                 "Benchmarks": "641",
@@ -153,7 +153,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "648",
+                "Scenario": "benchmark_648.exchange2_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intspeed",
                 "Benchmarks": "648",
@@ -169,7 +169,7 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "657",
+                "Scenario": "benchmark_657.xz_s",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intspeed",
                 "Benchmarks": "657",

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-INTSPEED.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-SPECCPU-INTSPEED.json
@@ -8,9 +8,9 @@
     },
     "Metadata": {
         "RecommendedMinimumExecutionTime": "(8-cores)=04:00:00,(16-cores)=06:00:00,(64-cores)=08:00:00",
-        "SupportedPlatforms": "linux-x64,linux-arm64,win-x64,win-arm64",
+        "SupportedPlatforms": "linux-x64,linux-arm64,win-x64",
         "SupportedOperatingSystems": "Azure Linux,CentOS,Debian,RedHat,Suse,Ubuntu,Windows",
-        "Notes": "Using a private package 'speccpu.2017.1.1.9-danielbowers.zip' to enable support for speccpu on Ubuntu 24",
+        "Notes": "Using a private package 'speccpu.2017.1.1.9-danielbowers.zip' to enable support for speccpu on Ubuntu 24. SPEC CPU 2017 was not initially designed for win-arm64.",
         "Limitations": "The following benchmarks don't work on Windows: 600, 602, 605, 620, 623, 625, 631, 648, 657"
     },
     "Parameters": {
@@ -19,7 +19,6 @@
         "RunPeak": false,
         "Threads": "{LogicalCoreCount}",
         "Copies": "{LogicalCoreCount}",
-        "Benchmarks": "{calculate(\"{Platform}\".StartsWith(\"linux\") ? \"intspeed\" : \"641\")}",
         "BaseOptimizingFlags": "-g -O3 -march={calculate(\"{Architecture}\" == \"x64\" ? \"native\" : \"armv8-a\")} -frecord-gcc-switches",
         "PeakOptimizingFlags": "-g -Ofast -march={calculate(\"{Architecture}\" == \"x64\" ? \"native\" : \"armv8-a\")} -flto -frecord-gcc-switches"
     },
@@ -27,16 +26,160 @@
         {
             "Type": "SpecCpuExecutor",
             "Parameters": {
-                "Scenario": "ExecuteSPECBenchmark",
+                "Scenario": "600",
                 "Iterations": "$.Parameters.Iterations",
                 "SpecProfile": "intspeed",
-                "Benchmarks": "$.Parameters.Benchmarks",
+                "Benchmarks": "600",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "602",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "intspeed",
+                "Benchmarks": "602",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "605",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "intspeed",
+                "Benchmarks": "605",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "620",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "intspeed",
+                "Benchmarks": "620",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "623",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "intspeed",
+                "Benchmarks": "623",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "625",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "intspeed",
+                "Benchmarks": "625",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "631",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "intspeed",
+                "Benchmarks": "631",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "641",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "intspeed",
+                "Benchmarks": "641",
                 "PackageName": "speccpu2017",
                 "RunPeak": "$.Parameters.RunPeak",
                 "Threads": "$.Parameters.Threads",
                 "Copies": "$.Parameters.Copies",
                 "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
                 "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "648",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "intspeed",
+                "Benchmarks": "648",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
+            }
+        },
+        {
+            "Type": "SpecCpuExecutor",
+            "Parameters": {
+                "Scenario": "657",
+                "Iterations": "$.Parameters.Iterations",
+                "SpecProfile": "intspeed",
+                "Benchmarks": "657",
+                "PackageName": "speccpu2017",
+                "RunPeak": "$.Parameters.RunPeak",
+                "Threads": "$.Parameters.Threads",
+                "Copies": "$.Parameters.Copies",
+                "BaseOptimizingFlags": "$.Parameters.BaseOptimizingFlags",
+                "PeakOptimizingFlags": "$.Parameters.PeakOptimizingFlags",
+                "SupportedPlatforms": "linux-x64,linux-arm64"
             }
         }
     ],

--- a/website/docs/workloads/speccpu/speccpu-profiles.md
+++ b/website/docs/workloads/speccpu/speccpu-profiles.md
@@ -18,7 +18,6 @@ for evaluating the performance of the CPU for processing calculations.
   * linux-x64
   * linux-arm64
   * win-x64
-  * win-arm64
 
   **Note**: On Windows platform, the **gcc** compiler version is required to be 10 or higher.  
 
@@ -76,7 +75,6 @@ for evaluating the performance of the CPU for processing calculations.
   * linux-x64
   * linux-arm64
   * win-x64
-  * win-arm64
 
   **Note**: Not supported currently on Ubuntu 24.
 
@@ -130,7 +128,6 @@ for evaluating the performance of the CPU for processing calculations.
   * linux-x64
   * linux-arm64
   * win-x64
-  * win-arm64
 
 * **Supports Disconnected Scenarios**  
   * No. Internet connection required.
@@ -181,7 +178,6 @@ for evaluating the performance of the CPU for processing calculations.
   * linux-x64
   * linux-arm64
   * win-x64
-  * win-arm64
 
 * **Supports Disconnected Scenarios**  
   * No. Internet connection required.


### PR DESCRIPTION
1. Moving speccpu benchmarks into separate actions.
2. Removing win-arm64 as a supported platform-architecture for speccpu.