### PR TITLE
Add send/receive suffix to full-duplex log file names

### DIFF
--- a/src/VirtualClient/VirtualClient.Actions/Network/NetworkingWorkload/NTttcp/NTttcpExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Network/NetworkingWorkload/NTttcp/NTttcpExecutor.cs
@@ -504,7 +504,7 @@ namespace VirtualClient.Actions.NetworkPerformance
                                     await this.LogProcessDetailsAsync(
                                         sendProcess,
                                         relatedContext,
-                                        "NTttcp",
+                                        "NTttcp-Send",
                                         results: new KeyValuePair<string, string>(this.SendResultsPath, sendResults));
 
                                     this.CaptureDirectionalMetrics(
@@ -518,7 +518,7 @@ namespace VirtualClient.Actions.NetworkPerformance
                                 }
                                 else
                                 {
-                                    await this.LogProcessDetailsAsync(sendProcess, relatedContext, "NTttcp");
+                                    await this.LogProcessDetailsAsync(sendProcess, relatedContext, "NTttcp-Send");
                                     this.Logger.LogMessage($"{this.TypeName}.FullDuplexSendFailed", LogLevel.Warning, relatedContext);
                                 }
 
@@ -531,7 +531,7 @@ namespace VirtualClient.Actions.NetworkPerformance
                                     await this.LogProcessDetailsAsync(
                                         receiveProcess,
                                         relatedContext,
-                                        "NTttcp",
+                                        "NTttcp-Receive",
                                         results: new KeyValuePair<string, string>(this.ReceiveResultsPath, receiveResults));
 
                                     this.CaptureDirectionalMetrics(
@@ -545,7 +545,7 @@ namespace VirtualClient.Actions.NetworkPerformance
                                 }
                                 else
                                 {
-                                    await this.LogProcessDetailsAsync(receiveProcess, relatedContext, "NTttcp");
+                                    await this.LogProcessDetailsAsync(receiveProcess, relatedContext, "NTttcp-Receive");
                                     this.Logger.LogMessage($"{this.TypeName}.FullDuplexReceiveFailed", LogLevel.Warning, relatedContext);
                                 }
 


### PR DESCRIPTION
In full-duplex mode, both send and receive processes were logged with the same tool name 'NTttcp', resulting in log files that were only distinguishable by timestamp. This makes it hard to identify which log belongs to the sender vs receiver.

Pass 'NTttcp-Send' and 'NTttcp-Receive' as the tool name to LogProcessDetailsAsync so log files are named:
  <timestamp>-ntttcp_tcp_4k_buffer_t1-send.log
  <timestamp>-ntttcp_tcp_4k_buffer_t1-receive.log