### PR TITLE
Fix ASP.NET workloads crashing on Windows due to Linux-only process commands

### DIFF
--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/AspNetBench/AspNetOrchardServerExecutorTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/AspNetBench/AspNetOrchardServerExecutorTests.cs
@@ -86,14 +86,16 @@ namespace VirtualClient.Actions
                 await executor.ExecuteAsync(CancellationToken.None);
 
                 this.mockFixture.Tracking.AssertCommandsExecuted(true,
-                    "pkill OrchardCore",
-                    "fuser -n tcp -k 5014",
+                    "taskkill /F /IM OrchardCore\\.Cms\\.Web\\.exe",
                     $"{Regex.Escape(this.mockDotNetPackage.Path)}\\\\dotnet\\.exe publish -c Release --sc -f net9\\.0 {Regex.Escape(this.mockOrchardCorePackage.Path)}\\\\src\\\\OrchardCore\\.Cms\\.Web\\\\OrchardCore\\.Cms\\.Web\\.csproj",
-                    $"nohup {Regex.Escape(this.mockOrchardCorePackage.Path)}\\\\src\\\\OrchardCore\\.Cms\\.Web\\\\bin\\\\Release\\\\net9\\.0\\\\win-x64\\\\publish\\\\OrchardCore\\.Cms\\.Web --urls http://\\*:5014"
+                    $"{Regex.Escape(this.mockOrchardCorePackage.Path)}\\\\src\\\\OrchardCore\\.Cms\\.Web\\\\bin\\\\Release\\\\net9\\.0\\\\win-x64\\\\publish\\\\OrchardCore\\.Cms\\.Web\\.exe --urls http://\\*:5014"
                 );
 
-                this.mockFixture.Tracking.AssertCommandExecutedTimes("pkill", 1);
-                this.mockFixture.Tracking.AssertCommandExecutedTimes("fuser", 1);
+                // On Windows the Linux-only 'pkill'/'fuser'/'nohup' commands must NOT be used.
+                this.mockFixture.Tracking.AssertCommandExecutedTimes("taskkill", 1);
+                this.mockFixture.Tracking.AssertCommandExecutedTimes("pkill", 0);
+                this.mockFixture.Tracking.AssertCommandExecutedTimes("fuser", 0);
+                this.mockFixture.Tracking.AssertCommandExecutedTimes("nohup", 0);
             }
         }
 

--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/AspNetBench/AspNetServerExecutorTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/AspNetBench/AspNetServerExecutorTests.cs
@@ -101,14 +101,15 @@ namespace VirtualClient.Actions
                 await executor.ExecuteAsync(CancellationToken.None);
 
                 this.mockFixture.Tracking.AssertCommandsExecuted(true,
-                    "pkill dotnet",
-                    "fuser -n tcp -k 9876",
+                    "taskkill /F /IM dotnet\\.exe",
                     $"{Regex.Escape(this.mockDotNetPackage.Path)}\\\\dotnet\\.exe build -c Release -p:BenchmarksTargetFramework=net8\\.0",
                     $"{Regex.Escape(this.mockDotNetPackage.Path)}\\\\dotnet\\.exe {Regex.Escape(this.mockAspNetBenchPackage.Path)}\\\\src\\\\Benchmarks\\\\bin\\\\Release\\\\net8\\.0\\\\Benchmarks\\.dll --nonInteractive true --scenarios json --urls http://\\*:9876 --server Kestrel --kestrelTransport Sockets --protocol http --header \\\"Accept: application/json,text/html;q=0\\.9,application/xhtml\\+xml;q=0\\.9,application/xml;q=0\\.8,\\*/\\*;q=0\\.7\\\" --header \\\"Connection: keep-alive\\\""
                 );
 
-                this.mockFixture.Tracking.AssertCommandExecutedTimes("pkill", 1);
-                this.mockFixture.Tracking.AssertCommandExecutedTimes("fuser", 1);
+                // On Windows the Linux-only 'pkill'/'fuser' commands must NOT be used; 'taskkill' is used instead.
+                this.mockFixture.Tracking.AssertCommandExecutedTimes("taskkill", 1);
+                this.mockFixture.Tracking.AssertCommandExecutedTimes("pkill", 0);
+                this.mockFixture.Tracking.AssertCommandExecutedTimes("fuser", 0);
             }
         }
 

--- a/src/VirtualClient/VirtualClient.Actions/ASPNET/AspNetOrchardServerExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/ASPNET/AspNetOrchardServerExecutor.cs
@@ -354,8 +354,20 @@ namespace VirtualClient.Actions
         private async Task KillServerInstancesAsync(EventContext telemetryContext, CancellationToken cancellationToken)
         {
             this.Logger.LogTraceMessage($"{this.TypeName}.KillServerInstances");
-            await this.ExecuteCommandAsync("pkill", "OrchardCore", this.aspnetOrchardDirectory, telemetryContext, cancellationToken);
-            await this.ExecuteCommandAsync("fuser", $"-n tcp -k {this.ServerPort}", this.aspnetOrchardDirectory, telemetryContext, cancellationToken);
+
+            // 'pkill'/'fuser' exist only on Unix; on Windows they fail to start ("The system cannot
+            // find the file specified"), which crashes the workload. On Windows the equivalent
+            // 'taskkill' is used to terminate the self-contained OrchardCore server (which also
+            // releases the TCP port it was holding).
+            if (this.Platform == PlatformID.Unix)
+            {
+                await this.ExecuteCommandAsync("pkill", "OrchardCore", this.aspnetOrchardDirectory, telemetryContext, cancellationToken);
+                await this.ExecuteCommandAsync("fuser", $"-n tcp -k {this.ServerPort}", this.aspnetOrchardDirectory, telemetryContext, cancellationToken);
+            }
+            else
+            {
+                await this.ExecuteCommandAsync("taskkill", "/F /IM OrchardCore.Cms.Web.exe", this.aspnetOrchardDirectory, telemetryContext, cancellationToken);
+            }
 
             await this.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
         }
@@ -368,9 +380,19 @@ namespace VirtualClient.Actions
             {
                 try
                 {
-                    string command = "nohup";
                     string workingDirectory = this.aspnetOrchardDirectory;
-                    string commandArguments = $"{this.Combine(this.aspnetOrchardPublishPath, "OrchardCore.Cms.Web")} --urls http://*:{this.ServerPort}";
+
+                    // 'nohup' (run a process immune to hangups, detached) exists only on Unix. On
+                    // Windows it fails to start ("The system cannot find the file specified"), so the
+                    // self-contained OrchardCore server executable is launched directly instead.
+                    string serverExecutable = this.Combine(
+                        this.aspnetOrchardPublishPath,
+                        this.Platform == PlatformID.Unix ? "OrchardCore.Cms.Web" : "OrchardCore.Cms.Web.exe");
+
+                    string command = this.Platform == PlatformID.Unix ? "nohup" : serverExecutable;
+                    string commandArguments = this.Platform == PlatformID.Unix
+                        ? $"{serverExecutable} --urls http://*:{this.ServerPort}"
+                        : $"--urls http://*:{this.ServerPort}";
 
                     relatedContext.AddContext("command", command);
                     relatedContext.AddContext("commandArguments", commandArguments);

--- a/src/VirtualClient/VirtualClient.Actions/ASPNET/AspNetServerExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/ASPNET/AspNetServerExecutor.cs
@@ -366,9 +366,21 @@ namespace VirtualClient.Actions
         {
             this.Logger.LogTraceMessage($"{this.TypeName}.KillServerInstances");
 
-            await this.ExecuteCommandAsync("pkill", "dotnet", this.aspnetBenchDirectory, telemetryContext, cancellationToken);
+            // The ASP.NET (Kestrel) benchmark server is hosted by the .NET runtime (dotnet). Both the
+            // server process(es) and the TCP port they hold must be released using platform-native
+            // commands. 'pkill'/'fuser' exist only on Unix; on Windows they fail to start
+            // ("The system cannot find the file specified"), which crashes the workload. On Windows the
+            // equivalent 'taskkill' is used instead (killing the process also releases its port).
+            if (this.Platform == PlatformID.Unix)
+            {
+                await this.ExecuteCommandAsync("pkill", "dotnet", this.aspnetBenchDirectory, telemetryContext, cancellationToken);
 
-            await this.ExecuteCommandAsync("fuser", $"-n tcp -k {this.ServerPort}", this.aspnetBenchDirectory, telemetryContext, cancellationToken);
+                await this.ExecuteCommandAsync("fuser", $"-n tcp -k {this.ServerPort}", this.aspnetBenchDirectory, telemetryContext, cancellationToken);
+            }
+            else
+            {
+                await this.ExecuteCommandAsync("taskkill", "/F /IM dotnet.exe", this.aspnetBenchDirectory, telemetryContext, cancellationToken);
+            }
 
             await this.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
         }

--- a/website/docs/workloads/aspnetbench/aspnetbench.md
+++ b/website/docs/workloads/aspnetbench/aspnetbench.md
@@ -22,6 +22,15 @@ server process to be pinned to specific CPU cores for controlled performance mea
 * [Bombardier Documentation](../bombardier/bombardier.md)
 * [Wrk/Wrk2 Documentation](../wrk/wrk.md)
 
+## Platform Support
+The ASP.NET Kestrel and OrchardCore server components run on all supported platforms (`linux-x64`, `linux-arm64`,
+`win-x64`, `win-arm64`). Each profile's overall platform support is determined by the HTTP client (load generator) it uses:
+
+* **Bombardier** is cross-platform, so `PERF-WEB-ASPNET-BOMBARDIER` runs on both Linux and Windows
+  (`linux-x64`, `linux-arm64`, `win-x64`, `win-arm64`).
+* **Wrk** is Linux-only, so the Wrk-based profiles (`PERF-WEB-ASPNET-WRK`, `PERF-WEB-ASPNET-WRK-AFFINITY`,
+  `PERF-WEB-ASPNET-ORCHARD-WRK`) run on `linux-x64` and `linux-arm64` only.
+
 ## What is Being Measured?
 The client tools (Bombardier, Wrk or Wrk2) generate concurrent HTTP requests against the ASP.NET server and capture latency
 percentile distributions and throughput statistics.


### PR DESCRIPTION
## Summary

`AspNetServerExecutor` and `AspNetOrchardServerExecutor` invoked Linux-only process commands unconditionally, so the ASP.NET workloads crashed on Windows even though both executors declare `[SupportedPlatforms("linux-arm64,linux-x64,win-arm64,win-x64")]`.

- `KillServerInstancesAsync` ran `pkill` and `fuser` (Unix-only). On Windows these fail to start (`Win32Exception: The system cannot find the file specified`), so the workload crash-loops until Virtual Client hits its restart-on-crash cap and the run fails with `System.AggregateException`.
- `AspNetOrchardServerExecutor.StartServerInstances` additionally launched the server via `nohup` (Unix-only) — the same failure mode.

## Fix

Make process cleanup and the Orchard server launch platform-aware:

- `KillServerInstancesAsync` — keep `pkill`/`fuser` on Unix; use `taskkill /F /IM <image>` on Windows (killing the process also frees the listening port).
- `AspNetOrchardServerExecutor.StartServerInstances` — keep `nohup` on Unix; launch the self-contained server executable directly on Windows.

The Unix code paths are unchanged. `taskkill` is consistent with the existing Windows kill path in `ProcessExtensions.SafeKill`. I intentionally did **not** switch to `ProcessManager.GetProcesses(...)` + `SafeKill`: the test `InMemoryProcessManager` does not override `GetProcesses`, so that path would call the real `Process.GetProcessesByName("dotnet")` during unit tests and could kill the test host's own `dotnet` processes.

## Testing

**Unit tests** — updated the Windows expectations in `AspNetServerExecutorTests` and `AspNetOrchardServerExecutorTests` (Linux tests unchanged). All ASP.NET tests pass (14/14).

**End-to-end on Azure VMs** — self-contained build run on a Windows and a Linux VM with `PERF-WEB-ASPNET-BOMBARDIER.json`, telemetry shipped to Kusto:

| | Windows (win-x64) | Linux (linux-x64) |
|---|---|---|
| AspNetServerExecutor | Succeeded ×21 | Succeeded ×10 |
| Bombardier result | ~76,198 req/s, ~3.43 ms avg latency (1.18M HTTP 200s/iteration) | ~72,573 req/s, ~3.53 ms |
| `pkill` / "cannot find the file" crashes | 0 | 0 |

Windows now runs the full ASP.NET Kestrel + Bombardier workload to completion. Both platforms produce near-identical benchmark results.

## Documentation

Added a **Platform Support** section to `aspnetbench.md` clarifying that the Bombardier-based profile is cross-platform (Windows + Linux) while the Wrk-based profiles are Linux-only (Wrk has no Windows build).
