### PR TITLE
Add database cleanup step before populating MySQL Sysbench databases

### DIFF
--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-MYSQL-SYSBENCH-OLTP.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-MYSQL-SYSBENCH-OLTP.json
@@ -246,6 +246,19 @@
         {
             "Type": "SysbenchConfiguration",
             "Parameters": {
+                "Scenario": "CleanupMySQLDatabase",
+                "Action": "Cleanup",
+                "DatabaseSystem": "MySQL",
+                "Benchmark": "OLTP",
+                "DatabaseName": "$.Parameters.DatabaseName",
+                "DatabaseScenario": "$.Parameters.DatabaseScenario",
+                "PackageName": "sysbench",
+                "Role": "Server"
+            }
+        },
+        {
+            "Type": "SysbenchConfiguration",
+            "Parameters": {
                 "Scenario": "PopulateMySQLDatabase",
                 "Action": "PopulateTables",
                 "DatabaseSystem": "MySQL",

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-MYSQL-SYSBENCH-TPCC.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-MYSQL-SYSBENCH-TPCC.json
@@ -134,6 +134,19 @@
         {
             "Type": "SysbenchConfiguration",
             "Parameters": {
+                "Scenario": "CleanupMySQLDatabase",
+                "Action": "Cleanup",
+                "DatabaseSystem": "MySQL",
+                "Benchmark": "TPCC",
+                "DatabaseName": "$.Parameters.DatabaseName",
+                "DatabaseScenario": "$.Parameters.DatabaseScenario",
+                "PackageName": "sysbench",
+                "Role": "Server"
+            }
+        },
+        {
+            "Type": "SysbenchConfiguration",
+            "Parameters": {
                 "Scenario": "PopulateMySQLDatabase",
                 "Action": "PopulateTables",
                 "DatabaseSystem": "MySQL",


### PR DESCRIPTION
## Summary
Adds a database **cleanup step** immediately before the `PopulateMySQLDatabase` dependency in both MySQL Sysbench profiles:
- `PERF-MYSQL-SYSBENCH-OLTP.json`
- `PERF-MYSQL-SYSBENCH-TPCC.json`

The new step uses the existing `SysbenchConfiguration` `Cleanup` action, which runs `cleanup-database.py` to drop tables left over from a previous run (guarded by `SysbenchState.DatabasePopulated`) before a new database is populated.

## Motivation
We are seeing MySQL server crashes & reconnects during these workloads. Independent of root-causing the load, populating on top of a stale/partially-populated database across repeated executions is a risk. Running cleanup first guarantees a clean slate before each populate.

## Testing
- JSON validated for both profiles.
- `dotnet test VirtualClient.Actions.FunctionalTests --filter Sysbench` → 10 passed, 6 ignored, 0 failed.