### PR TITLE
Fix DeathStarBench libssl install failing without root privileges

### DIFF
--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-NETWORK-DEATHSTARBENCH.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-NETWORK-DEATHSTARBENCH.json
@@ -86,7 +86,7 @@
       "Parameters": {
         "Scenario": "InstallLibssl",
         "SupportedPlatforms": "linux-x64",
-        "Command": "dpkg -i libssl1.0.0_1.0.2n-1ubuntu5.13_amd64.deb",
+        "Command": "sudo dpkg -i libssl1.0.0_1.0.2n-1ubuntu5.13_amd64.deb",
         "WorkingDirectory": "{PackagePath:libssl}"
       }
     },


### PR DESCRIPTION
## Problem
The `InstallLibssl` step in `PERF-NETWORK-DEATHSTARBENCH.json` ran `dpkg -i libssl1.0.0_1.0.2n-1ubuntu5.13_amd64.deb` **without `sudo`**.

VirtualClient only prepends `sudo` for steps that use `CreateElevatedProcess` (apt, Docker, etc.) — a plain `ExecuteCommand` runs verbatim as the non-root user. So `dpkg` failed with:

```
dpkg: error: requested operation requires superuser privilege
```

exit code 2 -> VC status **210506** (dependency install failed) -> crash-restart loop -> step fails. As a result `QoS_VC_..._PERF-NETWORK-DEATHSTARBENCH-linux-x64` effectively **never passed** (~0 successes across all versions in QoS telemetry).

## Fix
Prepend `sudo` to the `dpkg -i` command, matching existing VC convention (e.g. `DCGMIInstallation` uses `sudo dpkg -i`).

## Validation (fresh Azure VM, outside Juno)
Reproduced and fixed on a fresh **Standard_D4s_v6 linux-x64** VM with VirtualClient run **non-root** (user `evellanoweth`, uid 1000, passwordless sudo — mirroring Juno's `junovmadmin`). A/B on the identical environment, only `sudo` differs:

| Test | Profile command | Result |
|------|-----------------|--------|
| **A — unfixed** | `dpkg -i libssl…deb` | FAIL: `requested operation requires superuser privilege`, exit 2 -> status **210506** (reproduces the Juno failure) |
| **B — fixed** | `sudo dpkg -i libssl…deb` | PASS: 0 superuser errors; `InstallLibssl` passes -> apt -> Docker -> API server -> into the DeathStarBench workload |

Note: running via `sudo VirtualClient` (as root) does **not** surface the bug, because a plain `dpkg` then already runs as root — the failure only reproduces when VC runs non-root as it does under Juno.
