### PR TITLE
Fix StripeDisks leaving raid0 mount root-owned, breaking non-root MySQL/sysbench workloads

### DIFF
--- a/src/VirtualClient/VirtualClient.Dependencies.UnitTests/StripeDisksTests.cs
+++ b/src/VirtualClient/VirtualClient.Dependencies.UnitTests/StripeDisksTests.cs
@@ -64,6 +64,44 @@ namespace VirtualClient.Dependencies
         }
 
         [Test]
+        public async Task StripeDisksSetsFullPermissionsOnTheMountDirectoryForNonRootUser()
+        {
+            this.mockFixture.Parameters["DiskFilter"] = "OSDisk:false";
+
+            string expectedMountDir = $"/home/{Environment.UserName}/mnt_raid0";
+
+            // The striping script creates and mounts the volume with elevated privileges, leaving the
+            // mount point root-owned. Once mounted, the directory exists but is empty, which should
+            // trigger the permissions step so that a non-root user can create subdirectories under it.
+            this.mockFixture.Directory.Setup(d => d.Exists(expectedMountDir)).Returns(true);
+            this.mockFixture.Directory.Setup(d => d.EnumerateFileSystemEntries(expectedMountDir))
+                .Returns(Enumerable.Empty<string>());
+
+            bool permissionsApplied = false;
+            bool ownershipApplied = false;
+            this.mockFixture.ProcessManager.OnProcessCreated = (process) =>
+            {
+                if (process.FullCommand() == $"sudo chmod -R 777 \"{expectedMountDir}\"")
+                {
+                    permissionsApplied = true;
+                }
+
+                if (process.FullCommand() == $"sudo chown {Environment.UserName}:{Environment.UserName} \"{expectedMountDir}\"")
+                {
+                    ownershipApplied = true;
+                }
+            };
+
+            using (StripeDisks component = new StripeDisks(this.mockFixture.Dependencies, this.mockFixture.Parameters))
+            {
+                await component.ExecuteAsync(CancellationToken.None);
+            }
+
+            Assert.IsTrue(permissionsApplied);
+            Assert.IsTrue(ownershipApplied);
+        }
+
+        [Test]
         public async Task StripeDisksLimitsDisksByDiskCount()
         {
             this.mockFixture.Parameters["DiskFilter"] = "OSDisk:false";

--- a/src/VirtualClient/VirtualClient.Dependencies/StripeDisks.cs
+++ b/src/VirtualClient/VirtualClient.Dependencies/StripeDisks.cs
@@ -211,6 +211,26 @@ namespace VirtualClient.Dependencies
                     process.ThrowIfErrored<DependencyException>(errorReason: ErrorReason.DependencyInstallationFailed);
                 }
             }
+
+            // The striping script creates and mounts the volume with elevated privileges, leaving the
+            // mount point owned by root. We want the mount point and directory structure to be owned by
+            // the user executing the application. This helps to prevent permissions issues when the
+            // application (running non-elevated) later creates subdirectories under the mount point.
+            if (this.Platform == PlatformID.Unix
+                && !cancellationToken.IsCancellationRequested
+                && !string.IsNullOrEmpty(this.MountDirectory)
+                && this.fileSystem.Directory.Exists(this.MountDirectory))
+            {
+                string loggedInUser = this.PlatformSpecifics.GetLoggedInUser();
+
+                await this.systemManagement.SetFullPermissionsAsync(
+                    this.MountDirectory,
+                    this.Platform,
+                    telemetryContext,
+                    cancellationToken,
+                    loggedInUser,
+                    this.Logger);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

The `StripeDisks` dependency runs the platform striping script (`stripe_disks.sh`) with elevated privileges. A freshly-created ext4 filesystem is mounted owned by `root:root` (mode 755). When VirtualClient runs **non-elevated** (as it does in production, e.g. as `junovmadmin`) and a downstream component such as `MySQLServerConfiguration` calls the managed `Directory.CreateDirectory` to create a subdirectory under the mount point (e.g. `<mount>/mysql`), it fails with:

```
Access to the path '/home/junovmadmin/mnt_raid0/mysql' is denied. Permission denied
```

This has been failing sysbench MySQL QoS runs (500+ traces in a single day on build 3.3.3480.2277).

## Fix

Mirror what `MountDisks` already does: after the striping script mounts the volume, call `SetFullPermissionsAsync` on the striped mount directory (Linux only) so it is owned by the logged-in user (`sudo chmod -R 777` + `chown`). `MountDisks` only chmods volumes that lack an existing access path, so striped raid0 volumes were the one mount path skipping this step.

## Validation

Validated end-to-end on a `Standard_D16ds_v6` Azure VM running VirtualClient as a **non-root** user with `PERF-MYSQL-SYSBENCH-OLTP`:

- **Before the fix** (ExperimentId `bd8a84f2-bc81-4e78-8b3f-b852f9d5a8f6`): raid0 mount was `drwxr-xr-x root root`; `MySQLServerConfiguration` failed with `Access to the path '.../mnt_raid0/mysql' is denied`.
- **After the fix** (ExperimentId `7158ca1e-6f44-4755-8cd4-1cfa00c8a14c`): log shows `SetFullPermissions (directory = '/home/evellanoweth/mnt_raid0', owner = 'evellanoweth')`, the mount becomes `drwxrwxrwx evellanoweth evellanoweth`, 0 denied errors, and MySQL configuration (ConfigureServer, CreateDatabase, SetGlobalVariables) + sysbench execution all proceed successfully.

Unit tests: all 16 `StripeDisksTests` pass, including a new `StripeDisksSetsFullPermissionsOnTheMountDirectoryForNonRootUser` test.
