### PR TITLE
Fix PostgreSQL install failure on non-root VMs (missing sudo in install-server.py)

### DIFF
--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-POSTGRESQL-HAMMERDB-TPCC.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-POSTGRESQL-HAMMERDB-TPCC.json
@@ -80,7 +80,7 @@
             "Parameters": {
                 "Scenario": "DownloadPostgreSQLPackage",
                 "BlobContainer": "packages",
-                "BlobName": "postgresql.14.0.0.rev4.zip",
+                "BlobName": "postgresql.14.0.0.rev5.zip",
                 "PackageName": "postgresql",
                 "Extract": true
             }

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-POSTGRESQL-HAMMERDB-TPCH.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-POSTGRESQL-HAMMERDB-TPCH.json
@@ -80,7 +80,7 @@
             "Parameters": {
                 "Scenario": "DownloadPostgreSQLPackage",
                 "BlobContainer": "packages",
-                "BlobName": "postgresql.14.0.0.rev4.zip",
+                "BlobName": "postgresql.14.0.0.rev5.zip",
                 "PackageName": "postgresql",
                 "Extract": true
             }

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-POSTGRESQL-SYSBENCH-OLTP.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-POSTGRESQL-SYSBENCH-OLTP.json
@@ -183,7 +183,7 @@
             "Parameters": {
                 "Scenario": "DownloadPostgreSQLServerPackage",
                 "BlobContainer": "packages",
-                "BlobName": "postgresql.14.0.0.rev4.zip",
+                "BlobName": "postgresql.14.0.0.rev5.zip",
                 "PackageName": "postgresql",
                 "Extract": true,
                 "Role": "Server"

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-POSTGRESQL-SYSBENCH-TPCC.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-POSTGRESQL-SYSBENCH-TPCC.json
@@ -71,7 +71,7 @@
             "Parameters": {
                 "Scenario": "DownloadPostgreSQLServerPackage",
                 "BlobContainer": "packages",
-                "BlobName": "postgresql.14.0.0.rev4.zip",
+                "BlobName": "postgresql.14.0.0.rev5.zip",
                 "PackageName": "postgresql",
                 "Extract": true,
                 "Role": "Server"


### PR DESCRIPTION
## Problem
`PostgreSQLServerInstallation` runs `python3 install-server.py` **without elevation**. Inside the package's `install-server.py`, the repo-setup and `apt-key` lines used `sudo`, but the three effective install commands did **not**:

```python
subprocess.run('apt-get update', shell=True, check=True)
subprocess.run('apt-get -y install postgresql-14', shell=True, check=True)
subprocess.run('systemctl restart postgresql', shell=True, check=True)
```

When VirtualClient runs **non-root** (e.g. Juno QoS execution goals), `apt-get update` fails:

```
E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)
subprocess.CalledProcessError: Command 'apt-get update' returned non-zero exit status 100.
```

PostgreSQL never installs, so every `PERF-POSTGRESQL-*` QoS goal (SYSBENCH OLTP/TPCC, HAMMERDB TPCC/TPCH, x64 + arm64) fails with `PostgreSQLServerInstallation.ExecuteError` and emits no metrics.

## Fix
Added `sudo` to the three unprivileged commands in `install-server.py` for both `linux-x64` and `linux-arm64`, and republished the package as **`postgresql.14.0.0.rev5.zip`**. This PR updates the four `PERF-POSTGRESQL` profiles to reference `rev5`.

(`configure-server.py` and `setup-database.py` already used `sudo` correctly; only `install-server.py` was affected.)

## Validation (linux-x64 Azure VM, script run as non-root user)
- **rev4** `install-server.py` → reproduced `apt` lock **Permission denied**, exit 100 (matches PPE traces).
- **rev5** `install-server.py` → **PostgreSQL 14.23 installed**, `systemctl is-active postgresql` = **active**, `select version()` returns.

## Notes
- New blob `rev5` is additive; `rev4` is left untouched.
- Source-of-truth for these scripts is the blob package (not in-repo), so the `.py` change ships via the republished package and is documented here.
