### PR TITLE
Fix Redis readiness and telemetry logger null handling

### DIFF
--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/Redis/RedisServerExecutorTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/Redis/RedisServerExecutorTests.cs
@@ -100,6 +100,7 @@ namespace VirtualClient.Actions
 
                 this.fixture.Tracking.AssertCommandExecutedTimes("chmod", 1);
                 this.fixture.Tracking.AssertCommandExecutedTimes("numactl", 1);
+                Assert.IsTrue(executor.WaitForServerPortsReadyCalled);
             }
         }
 
@@ -189,9 +190,17 @@ namespace VirtualClient.Actions
             {
             }
 
+            public bool WaitForServerPortsReadyCalled { get; private set; }
+
             public new Task InitializeAsync(EventContext telemetryContext, CancellationToken cancellationToken)
             {
                 return base.InitializeAsync(telemetryContext, cancellationToken);
+            }
+
+            protected override Task WaitForServerPortsReadyAsync(EventContext telemetryContext, CancellationToken cancellationToken)
+            {
+                this.WaitForServerPortsReadyCalled = true;
+                return Task.CompletedTask;
             }
         }
     }

--- a/src/VirtualClient/VirtualClient.Actions/Redis/RedisServerExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Redis/RedisServerExecutor.cs
@@ -8,6 +8,7 @@ namespace VirtualClient.Actions
     using System.Linq;
     using System.Net;
     using System.Net.Http;
+    using System.Net.Sockets;
     using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
@@ -198,6 +199,7 @@ namespace VirtualClient.Actions
                         this.StartServerInstances(telemetryContext, cancellationToken);
                     }
 
+                    await this.WaitForServerPortsReadyAsync(telemetryContext, cancellationToken);
                     await this.SaveStateAsync(telemetryContext, cancellationToken);
                     this.SetServerOnline(true);
                     if (this.IsMultiRoleLayout())
@@ -266,6 +268,54 @@ namespace VirtualClient.Actions
                     $"when binding each of the servers to a logical core/vCPU. Set parameter '{nameof(this.BindToCores)}' = false to allow for additional server instances.",
                     ErrorReason.InvalidProfileDefinition);
             }
+        }
+
+        /// <summary>
+        /// Waits for each Redis server port to start accepting TCP connections.
+        /// </summary>
+        /// <param name="telemetryContext">Provides context information that will be captured with telemetry events.</param>
+        /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
+        protected virtual async Task WaitForServerPortsReadyAsync(EventContext telemetryContext, CancellationToken cancellationToken)
+        {
+            TimeSpan timeout = TimeSpan.FromMinutes(5);
+            DateTime deadline = DateTime.UtcNow.Add(timeout);
+            HashSet<int> pendingPorts = new HashSet<int>(Enumerable.Range(this.Port, this.ServerInstances));
+
+            this.Logger.LogTraceMessage($"{this.TypeName}: Waiting for Redis server ports {string.Join(',', pendingPorts)}...");
+
+            while (pendingPorts.Count > 0 && DateTime.UtcNow < deadline && !cancellationToken.IsCancellationRequested)
+            {
+                foreach (int port in pendingPorts.ToList())
+                {
+                    try
+                    {
+                        using (TcpClient client = new TcpClient())
+                        {
+                            await client.ConnectAsync(IPAddress.Loopback, port).ConfigureAwait(false);
+                            pendingPorts.Remove(port);
+                        }
+                    }
+                    catch (SocketException)
+                    {
+                    }
+                }
+
+                if (pendingPorts.Count > 0)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (pendingPorts.Count > 0)
+            {
+                throw new WorkloadException(
+                    $"The Redis server did not start accepting connections on port(s) {string.Join(',', pendingPorts)} within {timeout}.",
+                    ErrorReason.WorkloadFailed);
+            }
+
+            this.Logger.LogTraceMessage($"{this.TypeName}: Redis server ports are accepting connections.");
         }
 
         private async Task CaptureRedisVersionAsync(EventContext telemetryContext, CancellationToken token)

--- a/src/VirtualClient/VirtualClient.Core.UnitTests/Logging/EventHubTelemetryLoggerTests.cs
+++ b/src/VirtualClient/VirtualClient.Core.UnitTests/Logging/EventHubTelemetryLoggerTests.cs
@@ -140,6 +140,19 @@ namespace VirtualClient.Logging
             Assert.AreEqual(expectedTimestamp, eventBody["timestamp"].Value<DateTime>());
         }
 
+        [Test]
+        public void EventHubTelemetryLoggerSupportsStandardLoggerMessages()
+        {
+            TestEventHubTelemetryLogger logger = new TestEventHubTelemetryLogger(this.mockChannel, LogLevel.Information);
+
+            Assert.DoesNotThrow(() => logger.LogInformation("Status Code: 200, GET /api/heartbeat"));
+
+            JObject eventBody = JObject.Parse(logger.LastEvent.EventBody.ToString());
+            Assert.AreEqual("Status Code: 200, GET /api/heartbeat", eventBody["message"].ToString());
+            Assert.AreEqual(string.Empty, eventBody["operation_Id"].ToString());
+            Assert.AreEqual(string.Empty, eventBody["operation_ParentId"].ToString());
+        }
+
         private class TestEventHubTelemetryLogger : EventHubTelemetryLogger
         {
             public TestEventHubTelemetryLogger(EventHubTelemetryChannel channel, LogLevel level)
@@ -147,9 +160,16 @@ namespace VirtualClient.Logging
             {
             }
 
+            public EventData LastEvent { get; private set; }
+
             public new EventData CreateEventObject(string eventMessage, LogLevel logLevel, DateTime eventTimestamp, EventContext eventContext, object bufferInfo = null)
             {
                 return base.CreateEventObject(eventMessage, logLevel, eventTimestamp, eventContext, bufferInfo);
+            }
+
+            protected override void AddEventDataToChannel(EventData eventData)
+            {
+                this.LastEvent = eventData;
             }
         }
     }

--- a/src/VirtualClient/VirtualClient.Core.UnitTests/Logging/SerilogFileLoggerTests.cs
+++ b/src/VirtualClient/VirtualClient.Core.UnitTests/Logging/SerilogFileLoggerTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace VirtualClient.Logging
+{
+    using System.Collections.Generic;
+    using global::Serilog;
+    using global::Serilog.Core;
+    using global::Serilog.Events;
+    using Microsoft.Extensions.Logging;
+    using NUnit.Framework;
+
+    [TestFixture]
+    [Category("Unit")]
+    public class SerilogFileLoggerTests : MockFixture
+    {
+        [Test]
+        public void SerilogFileLoggerSupportsStandardLoggerMessages()
+        {
+            InMemoryLogEventSink sink = new InMemoryLogEventSink();
+            using (Logger serilogLogger = new LoggerConfiguration().WriteTo.Sink(sink).CreateLogger())
+            {
+                SerilogFileLogger logger = new SerilogFileLogger(serilogLogger, LogLevel.Information);
+
+                Assert.DoesNotThrow(() => logger.LogInformation("Status Code: 200, GET /api/heartbeat"));
+                Assert.AreEqual(1, sink.Events.Count);
+                Assert.AreEqual("Status Code: 200, GET /api/heartbeat", sink.Events[0].Properties["message"].ToString().Trim('"'));
+            }
+        }
+
+        private class InMemoryLogEventSink : ILogEventSink
+        {
+            public IList<LogEvent> Events { get; } = new List<LogEvent>();
+
+            public void Emit(LogEvent logEvent)
+            {
+                this.Events.Add(logEvent);
+            }
+        }
+    }
+}

--- a/src/VirtualClient/VirtualClient.Core/Logging/EventHubTelemetryLogger.cs
+++ b/src/VirtualClient/VirtualClient.Core/Logging/EventHubTelemetryLogger.cs
@@ -142,12 +142,15 @@ namespace VirtualClient.Logging
         protected virtual EventData CreateEventObject(string eventMessage, LogLevel logLevel, DateTime eventTimestamp, EventContext eventContext, object bufferInfo = null)
         {
             // Allow for specific property overrides.
-            eventContext.Properties.TryGetValue(MetadataContract.AppHost, out object appHost);
-            eventContext.Properties.TryGetValue(MetadataContract.AppName, out object appName);
-            eventContext.Properties.TryGetValue(MetadataContract.AppVersion, out object appVersion);
+            object appHost = null;
+            object appName = null;
+            object appVersion = null;
+            eventContext?.Properties?.TryGetValue(MetadataContract.AppHost, out appHost);
+            eventContext?.Properties?.TryGetValue(MetadataContract.AppName, out appName);
+            eventContext?.Properties?.TryGetValue(MetadataContract.AppVersion, out appVersion);
 
             DateTime timestamp = eventTimestamp;
-            if (eventContext.Properties.TryGetValue(MetadataContract.Timestamp, out object datetime))
+            if (eventContext?.Properties?.TryGetValue(MetadataContract.Timestamp, out object datetime) == true)
             {
                 DateTime.TryParse(datetime?.ToString(), out timestamp);
             }
@@ -248,7 +251,7 @@ namespace VirtualClient.Logging
             EventData eventData = this.CreateEventObject(eventMessage, logLevel, DateTime.UtcNow, eventContext, bufferInfo);
             if (eventData.Body.Length > EventHubTelemetryChannel.MaxEventDataBytes)
             {
-                EventContext scaledDownContext = eventContext.Clone(withProperties: false)
+                EventContext scaledDownContext = (eventContext?.Clone(withProperties: false) ?? new EventContext(Guid.NewGuid()))
                     .AddContext("exceededSizeLimits", bool.TrueString);
 
                 eventData = this.CreateEventObject(eventMessage, logLevel, DateTime.UtcNow, scaledDownContext, bufferInfo);

--- a/src/VirtualClient/VirtualClient.Core/Logging/SerilogFileLogger.cs
+++ b/src/VirtualClient/VirtualClient.Core/Logging/SerilogFileLogger.cs
@@ -94,7 +94,7 @@ namespace VirtualClient.Logging
                     else
                     {
                         // State context was provided by itself.
-                        eventMessage = state.ToString();
+                        eventMessage = state?.ToString();
                     }
                 }
 
@@ -104,9 +104,9 @@ namespace VirtualClient.Logging
                     new LogEventProperty("timestamp", new ScalarValue(DateTime.UtcNow.ToString("o"))),
                     new LogEventProperty("level", new ScalarValue(logLevel.ToString())),
                     new LogEventProperty("message", new ScalarValue(eventMessage)),
-                    new LogEventProperty("operationId", new ScalarValue(eventContext.ActivityId)),
-                    new LogEventProperty("transactionId", new ScalarValue(eventContext.TransactionId)),
-                    new LogEventProperty("durationMs", new ScalarValue(eventContext.DurationMs))
+                    new LogEventProperty("operationId", new ScalarValue(eventContext?.ActivityId ?? Guid.Empty)),
+                    new LogEventProperty("transactionId", new ScalarValue(eventContext?.TransactionId ?? Guid.Empty)),
+                    new LogEventProperty("durationMs", new ScalarValue(eventContext?.DurationMs ?? 0))
                 };
 
                 if (eventContext != null)
@@ -121,7 +121,7 @@ namespace VirtualClient.Logging
                     DateTime.Now, 
                     level, 
                     exception, 
-                    new MessageTemplateParser().Parse(eventMessage), 
+                    new MessageTemplateParser().Parse(eventMessage ?? string.Empty),
                     properties);
 
                 this.logger.Write(logEvent);


### PR DESCRIPTION
## Summary
- support standard `ILogger` messages without an `EventContext` in the Serilog file and Event Hub telemetry loggers
- wait for every configured Redis server TCP port before publishing `ServerState`
- add focused regression coverage for logger messages and Redis readiness

## Root cause
ASP.NET API middleware emits ordinary `ILogger` messages. The file logger dereferenced a null `EventContext`, aborting otherwise-successful heartbeat responses; the Event Hub logger had the same null-context defect and emitted `EventHubTelemetryLogger.LoggingError`. Redis then remained in heartbeat polling and clients received missing state/connection failures. Redis also published state without explicitly confirming ports 6379/6380 were accepting connections.

## Validation
- focused logger tests: 6 passed
- focused Redis executor tests: 5 passed
- ARM64 VM: `qos4redis-0715-c72a` (`Standard_D2ps_v6`)
- ExperimentId: `c9fe46be-07bd-42dc-9408-b3f381b88442`
- result: 0 error events, 0 failed outcomes, 6 successful client outcomes, 296 Memtier metric rows