### PR TITLE
Fix LZBench initialization permission failures

### DIFF
--- a/src/VirtualClient/VirtualClient.Actions.FunctionalTests/CompressionProfileTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.FunctionalTests/CompressionProfileTests.cs
@@ -185,7 +185,7 @@ namespace VirtualClient.Actions
                 $"sudo make",
                 $"wget https://sun.aei.polsl.pl//~sdeor/corpus/silesia.zip",
                 $"sudo unzip silesia.zip -d silesia",
-                $"sudo bash lzbenchexecutor.sh \"-t16,16 -eall -o4 -r /home/user/tools/VirtualClient/packages/lzbench/silesia\""
+                $"sudo bash \"/home/user/tools/VirtualClient/scripts/lzbench/lzbenchexecutor.sh\" \"-t16,16 -eall -o4 -r /home/user/tools/VirtualClient/packages/lzbench/silesia\""
             };
         }
     }

--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/Lzbench/LzbenchExecutorTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/Lzbench/LzbenchExecutorTests.cs
@@ -164,7 +164,7 @@ namespace VirtualClient.Actions
             };
             string mockPackagePath = this.mockPackage.Path;
 
-            string expectedCommand = $"sudo bash lzbenchexecutor.sh \"testOption1 testOption2 {this.mockFixture.PlatformSpecifics.Combine(mockPackagePath, "silesia")}\"";
+            string expectedCommand = $"sudo bash \"{this.mockFixture.PlatformSpecifics.GetScriptPath("lzbench", "lzbenchexecutor.sh")}\" \"testOption1 testOption2 {this.mockFixture.PlatformSpecifics.Combine(mockPackagePath, "silesia")}\"";
 
             bool commandExecuted = false;
             this.mockFixture.ProcessManager.OnCreateProcess = (exe, arguments, workingDir) =>
@@ -210,11 +210,12 @@ namespace VirtualClient.Actions
             string mockPackagePath = this.mockPackage.Path;
             List<string> expectedCommands = new List<string>
             {
+                $"sudo rm -rf \"{mockPackagePath}\"",
                 $"sudo git clone -b v1.8.1 https://github.com/inikep/lzbench.git",
                 $"sudo make",
                 $"sudo wget https://sun.aei.polsl.pl//~sdeor/corpus/silesia.zip",
                 $"sudo unzip silesia.zip -d silesia",
-                $"sudo bash lzbenchexecutor.sh \"testOption1 testOption2 {this.mockFixture.PlatformSpecifics.Combine(mockPackagePath, "silesia")}\""
+                $"sudo bash \"{this.mockFixture.PlatformSpecifics.GetScriptPath("lzbench", "lzbenchexecutor.sh")}\" \"testOption1 testOption2 {this.mockFixture.PlatformSpecifics.Combine(mockPackagePath, "silesia")}\""
             };
 
             int processCount = 0;
@@ -246,7 +247,7 @@ namespace VirtualClient.Actions
                 await LzbenchExecutor.ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
             }
 
-            Assert.IsTrue(processCount == 5);
+            Assert.IsTrue(processCount == 6);
         }
 
         [Test]
@@ -256,9 +257,10 @@ namespace VirtualClient.Actions
             string mockPackagePath = this.mockPackage.Path;
             List<string> expectedCommands = new List<string>
             {
+                $"sudo rm -rf \"{mockPackagePath}\"",
                 $"sudo git clone -b v1.8.1 https://github.com/inikep/lzbench.git",
                 $"sudo make",
-                $"sudo bash lzbenchexecutor.sh \"testOption1 testOption2 Test1.zip Test2.txt\"",
+                $"sudo bash \"{this.mockFixture.PlatformSpecifics.GetScriptPath("lzbench", "lzbenchexecutor.sh")}\" \"testOption1 testOption2 Test1.zip Test2.txt\"",
         };
 
             int processCount = 0;
@@ -290,7 +292,7 @@ namespace VirtualClient.Actions
                 await LzbenchExecutor.ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
             }
 
-            Assert.IsTrue(processCount == 3);
+            Assert.IsTrue(processCount == 4);
         }
 
         [Test]
@@ -300,7 +302,7 @@ namespace VirtualClient.Actions
             string mockPackagePath = this.mockPackage.Path;
             List<string> expectedCommands = new List<string>
             {
-                $"sudo bash lzbenchexecutor.sh \"testOption1 testOption2 Test1.zip Test2.txt\""
+                $"sudo bash \"{this.mockFixture.PlatformSpecifics.GetScriptPath("lzbench", "lzbenchexecutor.sh")}\" \"testOption1 testOption2 Test1.zip Test2.txt\""
             };
 
             int processCount = 0;

--- a/src/VirtualClient/VirtualClient.Actions/Lzbench/LzbenchExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Lzbench/LzbenchExecutor.cs
@@ -93,6 +93,14 @@ namespace VirtualClient.Actions
             }
         }
 
+        private string LzbenchScriptPath
+        {
+            get
+            {
+                return this.PlatformSpecifics.GetScriptPath("lzbench", "lzbenchexecutor.sh");
+            }
+        }
+
         /// <summary>
         /// Executes the Lzbench workload.
         /// </summary>
@@ -106,7 +114,7 @@ namespace VirtualClient.Actions
                 // We are attempting to add in a common method for execution of commands as we have seen throughout many executors.
                 // In the near term, we are going to add this in slowly and incrementally in order to avoid raising the likelihood
                 // of regressions.
-                using (IProcessProxy process = await this.ExecuteCommandAsync("bash", $"lzbenchexecutor.sh \"{commandLineArguments}\"", this.LzbenchDirectory, telemetryContext, cancellationToken, runElevated: true))
+                using (IProcessProxy process = await this.ExecuteCommandAsync("bash", $"\"{this.LzbenchScriptPath}\" \"{commandLineArguments}\"", this.LzbenchDirectory, telemetryContext, cancellationToken, runElevated: true))
                 {
                     if (!cancellationToken.IsCancellationRequested)
                     {
@@ -131,10 +139,15 @@ namespace VirtualClient.Actions
                 ?? new LzbenchState();
 
             if (!state.LzbenchInitialized)
-            {      
+            {
+                if (this.fileSystem.Directory.Exists(this.LzbenchDirectory))
+                {
+                    await this.ExecuteCommandAsync("rm", $"-rf \"{this.LzbenchDirectory}\"", this.PlatformSpecifics.PackagesDirectory, cancellationToken);
+                }
+
                 // Clone Lzbench code from git.
                 await this.ExecuteCommandAsync("git", $"clone -b v{this.Version} https://github.com/inikep/lzbench.git", this.PlatformSpecifics.PackagesDirectory, cancellationToken);
-                
+
                 // Build Lzbench.
                 await this.ExecuteCommandAsync("make", string.Empty, this.LzbenchDirectory, cancellationToken);
 
@@ -143,14 +156,6 @@ namespace VirtualClient.Actions
                 {
                     await this.ExecuteCommandAsync("wget", $"https://sun.aei.polsl.pl//~sdeor/corpus/silesia.zip", this.LzbenchDirectory, cancellationToken);
                     await this.ExecuteCommandAsync("unzip", "silesia.zip -d silesia", this.LzbenchDirectory, cancellationToken);
-                }
-
-                foreach (string file in this.fileSystem.Directory.GetFiles(this.PlatformSpecifics.GetScriptPath("lzbench")))
-                {
-                    this.fileSystem.File.Copy(
-                        file,
-                        this.Combine(this.LzbenchDirectory, Path.GetFileName(file)),
-                        true);
                 }
 
                 state.LzbenchInitialized = true;


### PR DESCRIPTION
## Summary
- run the packaged `lzbenchexecutor.sh` directly through elevated `bash` instead of copying it as the unprivileged VC user
- remove an existing partial LZBench clone before state-false initialization retries
- update unit and functional command expectations

## Root cause
QoS runs on both linux-x64 and linux-arm64 failed while copying the packaged script from the Juno-managed NuGet content tree with `UnauthorizedAccessException`. Because initialization state was never saved, subsequent profile iterations repeatedly ran `git clone` into the existing `lzbench` directory, producing millions of `destination path already exists` errors until the workload step timed out.

## Validation
- LZBench unit tests: 9 passed
- LZBench functional profile tests: 2 passed
- VM: `qoslzbench-07160952` (`Standard_D2s_v5`, linux-x64)
- fresh initialization experiment: `c184a75a-03aa-4ad8-8e06-223546bf5e34`
- forced partial-state recovery experiment: `b25f7b9e-ec93-4c2d-8452-cba9f3ad84f1`
- each VM run emitted 40 LZBench metrics, exited 0, and had zero severity-4, permission-denied, or clone-exists traces