### PR TITLE
Fix NAS MPI SSH host verification

### DIFF
--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/NASParallelBench/NASParallelBenchClientExecutorTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/NASParallelBench/NASParallelBenchClientExecutorTests.cs
@@ -117,8 +117,9 @@ namespace VirtualClient.Actions.NASParallelBench
             this.mockFixture.ProcessManager.OnCreateProcess = (cmd, args, wd) =>
             {
                 Assert.AreEqual(cmd, "sudo");
-                Assert.AreEqual(args, $"bash -c \"runuser -l my-username -c 'export OMP_NUM_THREADS" +
-                    $"={Environment.ProcessorCount} && export NPB_NPROCS_STRICT=off && mpiexec -np 2 " +
+                Assert.AreEqual(args, $"bash -c \"runuser -l my-username -c 'mkdir -p ~/.ssh && chmod 700 ~/.ssh " +
+                    $"&& ssh-keyscan -H 1.2.3.4 1.2.3.5 >> ~/.ssh/known_hosts && chmod 600 ~/.ssh/known_hosts " +
+                    $"&& export OMP_NUM_THREADS={Environment.ProcessorCount} && export NPB_NPROCS_STRICT=off && mpiexec -np 2 " +
                     $"--host 1.2.3.4,1.2.3.5 {this.mockFixture.GetPackagePath()}/nasparallelbench/" +
                     $"linux-x64/NPB-MPI/bin/bt.S.x'\"");
                 return this.mockFixture.Process;

--- a/src/VirtualClient/VirtualClient.Actions/NASParallelBench/NASParallelBenchClientExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/NASParallelBench/NASParallelBenchClientExecutor.cs
@@ -126,6 +126,7 @@ namespace VirtualClient.Actions
                 {
                     IEnumerable<string> allInstances = this.Layout.Clients.Select(cl => cl.IPAddress.ToString()).ToList();
                     string hosts = string.Join(",", allInstances);
+                    string sshHosts = string.Join(" ", allInstances);
                     scenarioArguments = $"-np {this.Layout.Clients.Count()} --host {hosts} {benchmarkPath}";
 
                     // It turns of the fixed number of processes required by the benchmark.
@@ -133,7 +134,8 @@ namespace VirtualClient.Actions
                     // On turning off the condition the workload will run with the maximum possible processes from the given number of processes.
                     // For example "-np 6", It will run with 4 processes.
                     string npbNprocsStrict = $"export NPB_NPROCS_STRICT=off";
-                    command = $"runuser -l {this.Username} -c \'{ompNumThreads} && {npbNprocsStrict} && mpiexec {scenarioArguments}\'";
+                    string configureSsh = $"mkdir -p ~/.ssh && chmod 700 ~/.ssh && ssh-keyscan -H {sshHosts} >> ~/.ssh/known_hosts && chmod 600 ~/.ssh/known_hosts";
+                    command = $"runuser -l {this.Username} -c \'{configureSsh} && {ompNumThreads} && {npbNprocsStrict} && mpiexec {scenarioArguments}\'";
                 }
                 else
                 {

--- a/website/docs/workloads/nasparallel/nasparallel-profiles.md
+++ b/website/docs/workloads/nasparallel/nasparallel-profiles.md
@@ -81,7 +81,7 @@ OpenMPI sends messages over port 22 - as well as expects to send messages withou
 client machine. Here is an example [blog post](https://linuxize.com/post/how-to-setup-passwordless-ssh-login/) on how to do this. Although the basic steps are:
 - On client, store a private-public key pair under ~/.ssh/id_rsa and ~/.ssh/id_rsa.pub
 - On server, append the id_rsa.pub generated under ~/.ssh/authorized_keys
-- On client, store server fingerprints in ~/.ssh/known_hosts 
+- Virtual Client records the participating systems' SSH host fingerprints in ~/.ssh/known_hosts before starting OpenMPI.
 - Last when running the profile, supply the username whose .ssh directory contains all of the files just created/edited. 
 
 ## Resource Requirements


### PR DESCRIPTION
## Problem
ARM64 client/server NAS Parallel Bench runs install OpenMPI and build NPB-MPI successfully, but `mpiexec` exits 255 when it tries to launch remote daemons:

```
Host key verification failed.
ORTE was unable to reliably start one or more daemons.
```

Single-node runs are unaffected because they use NPB-OMP and do not require SSH.

Historically, this target emitted valid NAS workload metrics, but the latest retained valid success was June 26, 2025. Current telemetry contains 48 affected experiments showing `Host key verification failed` since June 11, 2026.

## Fix
- Populate the workload user's `~/.ssh/known_hosts` with every participating layout IP before invoking `mpiexec`.
- Preserve SSH host verification rather than disabling it globally.
- Update the exact-command unit test and workload documentation.

Passwordless SSH authentication remains a prerequisite.

## Validation
- 10 targeted `NASParallelBenchClientExecutorTests` pass.
- Validated on two Ubuntu ARM64 `Standard_D16ps_v6` VMs with an initially empty client `known_hosts`.
- The generated `ssh-keyscan && mpiexec` sequence launched NPB-MPI across both nodes and completed EP class S with verification successful, `Mop/s total = 313.98`, and exit code 0.

Representative failing QoS experiments: `b3662c29-275f-4e95-a55a-adf1ae002591`, `a78517bf-8c96-45d5-bb2d-cdd56192374a`.