### PR TITLE
Fix SPECjvm result file permissions

### DIFF
--- a/src/VirtualClient/VirtualClient.Actions.FunctionalTests/SpecJvmProfileTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.FunctionalTests/SpecJvmProfileTests.cs
@@ -188,7 +188,7 @@ namespace VirtualClient.Actions
                 case PlatformID.Unix:
                     commands = new List<string>
                     {
-                        @"sudo java -XX:ParallelGCThreads=[0-9]+ -XX:\+UseParallelGC -XX:\+UseAES -XX:\+UseSHA -Xms[0-9]+m -Xmx[0-9]+m -jar SPECjvm2008.jar -ikv -ict compress crypto derby mpegaudio scimark serial sunflow"
+                        @"^java -XX:ParallelGCThreads=[0-9]+ -XX:\+UseParallelGC -XX:\+UseAES -XX:\+UseSHA -Xms[0-9]+m -Xmx[0-9]+m -jar SPECjvm2008.jar -ikv -ict compress crypto derby mpegaudio scimark serial sunflow$"
                     };
                     break;
             }

--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/SPEC/SpecJvmExecutorTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/SPEC/SpecJvmExecutorTests.cs
@@ -95,7 +95,7 @@ namespace VirtualClient.Actions
         {
             this.SetupDefaultBehaviors(PlatformID.Unix);
 
-            string expectedCommand = $@"sudo java -XX:ParallelGCThreads=[0-9]+ -XX:\+UseParallelGC -XX:\+UseAES -XX:\+UseSHA -Xms[0-9]+m -Xmx[0-9]+m -jar SPECjvm2008.jar -ikv -ict test1 test2";
+            string expectedCommand = $@"^java -XX:ParallelGCThreads=[0-9]+ -XX:\+UseParallelGC -XX:\+UseAES -XX:\+UseSHA -Xms[0-9]+m -Xmx[0-9]+m -jar SPECjvm2008.jar -ikv -ict test1 test2$";
 
             bool commandExecuted = false;
             this.mockFixture.ProcessManager.OnCreateProcess = (exe, arguments, workingDir) =>

--- a/src/VirtualClient/VirtualClient.Actions/SPECjvm/SpecJvmExecutor.cs
+++ b/src/VirtualClient/VirtualClient.Actions/SPECjvm/SpecJvmExecutor.cs
@@ -129,7 +129,9 @@ namespace VirtualClient.Actions
                 {
                     using (BackgroundOperations profiling = BackgroundOperations.BeginProfiling(this, cancellationToken))
                     {
-                        using (IProcessProxy process = this.systemManagement.ProcessManager.CreateElevatedProcess(this.Platform, pathToExe, commandLineArguments, workingDirectory))
+                        // SPECjvm writes result files into the package directory. Run as the Virtual Client user
+                        // so the executor can read and delete those files after the process completes.
+                        using (IProcessProxy process = this.systemManagement.ProcessManager.CreateProcess(pathToExe, commandLineArguments, workingDirectory))
                         {
                             this.CleanupTasks.Add(() => process.SafeKill(this.Logger));
                             this.LogProcessTrace(process);


### PR DESCRIPTION
## Problem

SPECjvm runs Java through `CreateElevatedProcess` on Linux. Java therefore creates result files as root, while Virtual Client runs as `junovmadmin` and fails when reading or deleting those files.

Recent PPE failures affect both targets:
- `QoS_VC_PERF-SPECJVM-linux-x64`
- `QoS_VC_ARM64_PERF-SPECJVM-linux-arm64`

The workload itself exits successfully, but result collection fails with `Access to the path .../results/SPECjvm2008.*/SPECjvm2008.*.txt is denied`.

## Change

- Run the SPECjvm Java process as the Virtual Client user instead of through `sudo`.
- Update unit and functional command expectations to prevent Linux elevation from being reintroduced.

## Validation

- Targeted `SpecJvm` unit tests pass.
- Targeted `SpecJvm` functional tests pass.