### PR TITLE
Upgrade OpenSSL to 3.5.7 (LTS) for linux-x64, linux-arm64, win-x64

### DIFF
--- a/src/VirtualClient/VirtualClient.Main/profiles/GET-STARTED-OPENSSL.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/GET-STARTED-OPENSSL.json
@@ -22,7 +22,7 @@
             "Parameters": {
                 "Scenario": "InstallOpenSSLWorkloadPackage",
                 "BlobContainer": "packages",
-                "BlobName": "openssl.3.0.0.zip",
+                "BlobName": "openssl.3.5.7.zip",
                 "PackageName": "openssl",
                 "Extract": true
             }

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-CPU-OPENSSL-TLS.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-CPU-OPENSSL-TLS.json
@@ -342,7 +342,7 @@
             "Parameters": {
                 "Scenario": "InstallOpenSSLPackage",
                 "BlobContainer": "packages",
-                "BlobName": "openssl.3.0.0.zip",
+                "BlobName": "openssl.3.5.7.zip",
                 "PackageName": "openssl",
                 "Extract": true
             }

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-CPU-OPENSSL.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-CPU-OPENSSL.json
@@ -159,7 +159,7 @@
             "Parameters": {
                 "Scenario": "InstallOpenSSLPackage",
                 "BlobContainer": "packages",
-                "BlobName": "openssl.3.0.0.zip",
+                "BlobName": "openssl.3.5.7.zip",
                 "PackageName": "openssl",
                 "Extract": true
             }


### PR DESCRIPTION
The previously packaged OpenSSL 3.5.0 binaries were built on Ubuntu 24.04, which links against a newer glibc than Ubuntu 22.04 provides. Running the workload on Ubuntu 22.04 (linux-arm64 in particular), failed with a library version mismatch that are unavailable on 22.04's glibc 2.35.

The new 3.5.7 packages are built on Ubuntu 22.04 instead. Because glibc is backward compatible, binaries built against the older glibc run correctly on both Ubuntu 22.04 and 24.04. Moving the build baseline down resolves the failure and widens OS coverage.

The 3.5.7 version package has been uploaded to the storage account and tested on Ubuntu 22.04 and 24.04.