### PR TITLE
Synchronize MySQL sysbench database population across roles

### DIFF
--- a/.github/workflows/pull-request-linux.yml
+++ b/.github/workflows/pull-request-linux.yml
@@ -26,10 +26,10 @@ jobs:
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 9.0.x
 
@@ -37,7 +37,7 @@ jobs:
       run: chmod -R +x *.sh
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,6 +54,6 @@ jobs:
       run: ./build-test.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,16 +26,16 @@ jobs:
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 9.0.x
 
     - name: Initialize CodeQL
       if: false # this is causing PR to fail on Windows with single slashes on Windows, temporarily disabling since we have it in Linux PR
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,6 +53,6 @@ jobs:
 
     - name: Perform CodeQL Analysis
       if: false # this is causing PR to fail on Windows with single slashes on Windows, temporarily disabling since we have it in Linux PR
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,7 @@
 		<PackageVersion Include="Polly" Version="8.5.0" />
 		<PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.2" />
 		<PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
-		<PackageVersion Include="SSH.NET" Version="2024.2.0" />
+		<PackageVersion Include="SSH.NET" Version="2026.0.0" />
 		<PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
 		<PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
 		<PackageVersion Include="System.Diagnostics.EventLog" Version="9.0.9" />

--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/Sysbench/SysbenchConfigurationTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/Sysbench/SysbenchConfigurationTests.cs
@@ -119,6 +119,50 @@ namespace VirtualClient.Actions
         }
 
         [Test]
+        public async Task SysbenchConfigurationWaitsForServerDependenciesBeforeRemotePopulation()
+        {
+            this.fixture.StateManager.OnGetState().ReturnsAsync(JObject.FromObject(new SysbenchExecutor.SysbenchState()
+            {
+                SysbenchInitialized = true
+            }));
+
+            bool serverHeartbeatConfirmed = false;
+            this.fixture.ApiClient.OnGetHeartbeat().ReturnsAsync(() =>
+            {
+                serverHeartbeatConfirmed = true;
+                return this.fixture.CreateHttpResponse(HttpStatusCode.OK);
+            });
+
+            this.fixture.ProcessManager.OnCreateProcess = (exe, arguments, workingDir) =>
+            {
+                Assert.IsTrue(serverHeartbeatConfirmed);
+
+                return new InMemoryProcess
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = exe,
+                        Arguments = arguments
+                    },
+                    ExitCode = 0,
+                    OnStart = () => true,
+                    OnHasExited = () => true
+                };
+            };
+
+            using (TestSysbenchConfiguration sysbenchConfiguration = new TestSysbenchConfiguration(this.fixture.Dependencies, this.fixture.Parameters))
+            {
+                await sysbenchConfiguration.ExecuteAsync(CancellationToken.None);
+            }
+
+            this.fixture.ApiClient.Verify(
+                client => client.GetHeartbeatAsync(
+                    It.IsAny<CancellationToken>(),
+                    It.IsAny<IAsyncPolicy<HttpResponseMessage>>()),
+                Times.Once);
+        }
+
+        [Test]
         public async Task SysbenchConfigurationPreparesDatabase()
         {
             string[] expectedCommands =

--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/Sysbench/SysbenchConfigurationTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/Sysbench/SysbenchConfigurationTests.cs
@@ -21,6 +21,7 @@ namespace VirtualClient.Actions
     using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
+    using VirtualClient.Common;
     using VirtualClient.Common.Contracts;
     using VirtualClient.Common.Telemetry;
     using VirtualClient.Contracts;
@@ -160,6 +161,40 @@ namespace VirtualClient.Actions
             using (TestSysbenchConfiguration SysbenchExecutor = new TestSysbenchConfiguration(this.fixture.Dependencies, this.fixture.Parameters))
             {
                 await SysbenchExecutor.ExecuteAsync(CancellationToken.None);
+            }
+        }
+
+        [Test]
+        public void SysbenchConfigurationThrowsWhenPopulationReportsFatalError()
+        {
+            this.fixture.StateManager.OnGetState().ReturnsAsync(JObject.FromObject(new SysbenchExecutor.SysbenchState()
+            {
+                SysbenchInitialized = true
+            }));
+
+            this.fixture.ProcessManager.OnCreateProcess = (exe, arguments, workingDir) =>
+            {
+                return new InMemoryProcess
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = exe,
+                        Arguments = arguments
+                    },
+                    ExitCode = 0,
+                    OnStart = () => true,
+                    OnHasExited = () => true,
+                    StandardOutput = new ConcurrentBuffer(new StringBuilder(
+                        "FATAL: error 1130: Host '10.0.1.0' is not allowed to connect to this MySQL server"))
+                };
+            };
+
+            using (TestSysbenchConfiguration sysbenchConfiguration = new TestSysbenchConfiguration(this.fixture.Dependencies, this.fixture.Parameters))
+            {
+                WorkloadException error = Assert.ThrowsAsync<WorkloadException>(
+                    () => sysbenchConfiguration.ExecuteAsync(CancellationToken.None));
+
+                Assert.AreEqual(ErrorReason.WorkloadUnexpectedAnomaly, error.Reason);
             }
         }
 

--- a/src/VirtualClient/VirtualClient.Actions/Sysbench/SysbenchConfiguration.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Sysbench/SysbenchConfiguration.cs
@@ -131,6 +131,14 @@ namespace VirtualClient.Actions
                             await this.LogProcessDetailsAsync(process, telemetryContext, "Sysbench", logToFile: true);
                             process.ThrowIfErrored<WorkloadException>(process.StandardError.ToString(), ErrorReason.WorkloadUnexpectedAnomaly);
 
+                            if (process.StandardOutput.ToString().Contains("FATAL:", StringComparison.OrdinalIgnoreCase)
+                                || process.StandardError.ToString().Contains("FATAL:", StringComparison.OrdinalIgnoreCase))
+                            {
+                                throw new WorkloadException(
+                                    "Sysbench reported a fatal error while populating the database.",
+                                    ErrorReason.WorkloadUnexpectedAnomaly);
+                            }
+
                             this.AddPopulationDurationMetric(sysbenchLoggingArguments, process, telemetryContext, cancellationToken);
 
                             state.DatabasePopulated = true;

--- a/src/VirtualClient/VirtualClient.Actions/Sysbench/SysbenchConfiguration.cs
+++ b/src/VirtualClient/VirtualClient.Actions/Sysbench/SysbenchConfiguration.cs
@@ -31,6 +31,7 @@ namespace VirtualClient.Actions
             : base(dependencies, parameters)
         {
             this.stateManager = this.Dependencies.GetService<IStateManager>();
+            this.PollingTimeout = TimeSpan.FromMinutes(10);
         }
 
         /// <summary>
@@ -44,6 +45,11 @@ namespace VirtualClient.Actions
                 return action?.ToString();
             }
         }
+
+        /// <summary>
+        /// The amount of time to wait for the server dependencies to complete.
+        /// </summary>
+        protected TimeSpan PollingTimeout { get; set; }
 
         /// <summary>
         /// Executes the workload.
@@ -110,6 +116,14 @@ namespace VirtualClient.Actions
 
             if (!state.DatabasePopulated)
             {
+                if (this.IsMultiRoleLayout() && this.IsInRole(ClientRole.Client))
+                {
+                    this.Logger.LogTraceMessage("Synchronization: Poll server API for heartbeat before database population...");
+
+                    await this.ServerApiClient.PollForHeartbeatAsync(this.PollingTimeout, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+
                 await this.Logger.LogMessageAsync($"{this.TypeName}.PopulateDatabase", telemetryContext.Clone(), async () =>
                 {
                     string serverIp = (this.IsMultiRoleLayout() && this.IsInRole(ClientRole.Client)) ? this.ServerIpAddress : "localhost";

--- a/src/VirtualClient/VirtualClient.Core.UnitTests/SshClientProxyTests.cs
+++ b/src/VirtualClient/VirtualClient.Core.UnitTests/SshClientProxyTests.cs
@@ -77,6 +77,7 @@ namespace VirtualClient
                 Assert.IsTrue(object.ReferenceEquals(expectedInfo, client.ConnectionInfo));
                 Assert.IsTrue(object.ReferenceEquals(expectedInfo, client.SessionClient.ConnectionInfo));
                 Assert.IsTrue(object.ReferenceEquals(expectedInfo, client.SessionScpClient.ConnectionInfo));
+                Assert.IsTrue(object.ReferenceEquals(RemotePathTransformation.ShellQuote, client.SessionScpClient.RemotePathTransformation));
             }
         }
 

--- a/src/VirtualClient/VirtualClient.Core/SshClientProxy.cs
+++ b/src/VirtualClient/VirtualClient.Core/SshClientProxy.cs
@@ -34,7 +34,7 @@ namespace VirtualClient
         {
             connectionInfo.ThrowIfNull(nameof(connectionInfo));
             this.SessionClient = new SshClient(connectionInfo);
-            this.SessionScpClient = new ScpClient(connectionInfo);
+            this.SessionScpClient = new ScpClient(connectionInfo, RemotePathTransformation.ShellQuote);
         }
 
         /// <summary>

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-MYSQL-SYSBENCH-OLTP.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-MYSQL-SYSBENCH-OLTP.json
@@ -182,7 +182,7 @@
             "Parameters": {
                 "Scenario": "DownloadMySqlServerPackage",
                 "BlobContainer": "packages",
-                "BlobName": "mysql-server-8.0.36-v5.zip",
+                "BlobName": "mysql-server-8.0.46-v1.zip",
                 "PackageName": "mysql-server",
                 "Extract": true,
                 "Role": "Server"

--- a/src/VirtualClient/VirtualClient.Main/profiles/PERF-MYSQL-SYSBENCH-TPCC.json
+++ b/src/VirtualClient/VirtualClient.Main/profiles/PERF-MYSQL-SYSBENCH-TPCC.json
@@ -70,7 +70,7 @@
             "Parameters": {
                 "Scenario": "DownloadMySqlServerPackage",
                 "BlobContainer": "packages",
-                "BlobName": "mysql-server-8.0.36-v5.zip",
+                "BlobName": "mysql-server-8.0.46-v1.zip",
                 "PackageName": "mysql-server",
                 "Extract": true,
                 "Role": "Server"


### PR DESCRIPTION
## Summary
- Prevent the first client-side database population step from racing MySQL server configuration and remote-user creation by waiting for the server API heartbeat.
- Detect sysbench `FATAL` output during database population even when sysbench returns exit code 0.
- Update the OLTP and TPCC profiles to use `mysql-server-8.0.46-v1.zip`.
- Upgrade SSH.NET and the PR workflow actions to supported versions so repository CI can restore and run.
- The MySQL package is uploaded to `virtualclientinternal/packages`.

## Root cause
The thread-sweep profile performs database population as a client-role action, while MySQL user creation is a server-role dependency. The first 8-thread population could reach MySQL after it started listening but before `setup-database.py` created `sbtest@10.0.1.0`, producing MySQL error 1130. Later thread counts succeeded because server configuration had completed.

The observed `FATAL: error 1130` lines were from the pre-fix reproduction. They are not expected after synchronization. The explicit `FATAL` detection remains as a safety net because sysbench returned exit code 0 for that failure; without it, VirtualClient could falsely mark database population successful.

## Validation
- All 10 `SysbenchConfigurationTests` pass, including regressions that verify the server heartbeat is confirmed before remote population starts and that fatal sysbench output fails the action.
- All 21 `SshClientProxyTests` pass with SSH.NET 2026.0.0.
- Direct pre-fix VM reproduction produced repeated `FATAL` connection errors with `SYSBENCH_EXIT_CODE=0`.
- VM experiment `85c95316-8775-46ea-9895-2bc3e6a229dc` passed targeted `oltp_read_write` with exit code 0 and no fatal connection error.
- VM experiment `27093927-fa27-421f-b3ad-10a30eefc94a` passed with MySQL `8.0.46-0ubuntu0.24.04.3`: 8,303.22 transactions/sec, 166,064.44 queries/sec, 0 ignored errors, and 0 reconnects.